### PR TITLE
feat(article-display): render articles with thumbnails from guardian and nytimes api

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,9 @@ import { getNewYorkTimesApiArticles } from "@/lib/actions/newYorkTimesApi.action
 import { getNewsApiArticles } from "@/lib/actions/newsApi.actions";
 import { shuffleArray } from "@/lib/helpers";
 
+const NEW_YORK_TIMES_IMAGES_BASE_URL =
+  process.env.NEW_YORK_TIMES_IMAGES_BASE_URL;
+
 const mapNewsApiArticles = (data?: {
   status: string;
   totalResults: number;
@@ -33,12 +36,12 @@ const mapGuardianApiArticles = (data?: {
     results: GuardianAPIArticle[];
   };
 }) =>
-  data?.response.results.map(({ webTitle, webUrl }) => ({
-    title: webTitle,
-    description: "",
-    imageUrl: "",
+  data?.response.results.map(({ fields }) => ({
+    title: fields.headline,
+    description: fields.trailText,
+    imageUrl: fields.thumbnail,
     source: "Guardian",
-    url: webUrl,
+    url: fields.shortUrl,
   })) || [];
 
 const mapNewYorkTimesArticles = (data?: {
@@ -49,10 +52,10 @@ const mapNewYorkTimesArticles = (data?: {
     time: number;
   };
 }) =>
-  data?.docs.map(({ web_url, headline, abstract, source }) => ({
+  data?.docs.map(({ web_url, headline, abstract, source, multimedia }) => ({
     title: headline.main,
     description: abstract,
-    imageUrl: "",
+    imageUrl: `${NEW_YORK_TIMES_IMAGES_BASE_URL}${multimedia?.[0]?.url}`,
     source,
     url: web_url,
   })) || [];

--- a/src/lib/actions/guardianApi.actions.ts
+++ b/src/lib/actions/guardianApi.actions.ts
@@ -2,7 +2,19 @@
 
 import { guardianApiClient } from "@/lib/api-clients/guardianApiClient";
 
-export const getGuardianApiArticles = async ({ page }: { page: string }) => {
+export const getGuardianApiArticles = async ({
+  page,
+  keyword,
+  fromDate,
+  toDate,
+  category,
+}: {
+  page: string;
+  keyword?: string;
+  fromDate?: string;
+  toDate?: string;
+  category?: string;
+}) => {
   try {
     const response = await guardianApiClient.get<{
       response: {
@@ -19,6 +31,13 @@ export const getGuardianApiArticles = async ({ page }: { page: string }) => {
     }>("/search", {
       params: {
         page: page || "1",
+        "page-size": 10,
+        format: "json",
+        "show-fields": "headline,thumbnail,short-url,trailText",
+        q: keyword,
+        "form-date": fromDate,
+        "to-date": toDate,
+        section: category,
       },
     });
 

--- a/src/lib/actions/newYorkTimesApi.actions.ts
+++ b/src/lib/actions/newYorkTimesApi.actions.ts
@@ -4,8 +4,14 @@ import { newYorkTimesApiClient } from "@/lib/api-clients/newYorkTimesApiClient";
 
 export const getNewYorkTimesApiArticles = async ({
   page,
+  keyword,
+  fromDate,
+  toDate,
 }: {
   page: string;
+  keyword?: string;
+  fromDate?: string;
+  toDate?: string;
 }) => {
   try {
     const response = await newYorkTimesApiClient.get<{
@@ -22,6 +28,9 @@ export const getNewYorkTimesApiArticles = async ({
     }>("/articlesearch.json", {
       params: {
         page: page || "1",
+        q: keyword,
+        begin_date: fromDate,
+        end_date: toDate,
       },
     });
 

--- a/src/lib/actions/newsApi.actions.ts
+++ b/src/lib/actions/newsApi.actions.ts
@@ -3,7 +3,17 @@
 import { newsApiClient } from "@/lib/api-clients/newsApiClient";
 import { NewsAPISources } from "@/lib/enums/news.enums";
 
-export const getNewsApiArticles = async ({ page }: { page: string }) => {
+export const getNewsApiArticles = async ({
+  page,
+  keyword,
+  fromDate,
+  toDate,
+}: {
+  page: string;
+  keyword?: string;
+  fromDate?: string;
+  toDate?: string;
+}) => {
   try {
     const response = await newsApiClient.get<{
       status: string;
@@ -14,6 +24,9 @@ export const getNewsApiArticles = async ({ page }: { page: string }) => {
         page: page || "1",
         sources: `${NewsAPISources.BBC_NEWS}, ${NewsAPISources.ABC_NEWS}, ${NewsAPISources.BLOOMBERG}`,
         pageSize: 10,
+        q: keyword,
+        from: fromDate,
+        to: toDate,
       },
     });
 

--- a/src/lib/types/guardianApi.d.ts
+++ b/src/lib/types/guardianApi.d.ts
@@ -8,6 +8,12 @@ type GuardianAPIArticle = {
   webTitle: string;
   webUrl: string;
   apiUrl: string;
+  fields: {
+    headline: string;
+    trailText: string;
+    shortUrl: string;
+    thumbnail: string;
+  };
   isHosted: boolean;
   pillarId: string;
   pillarName: string;


### PR DESCRIPTION
- Implemented functionality to fetch and display articles with thumbnail images from both the 'Guardian API' and the 'New York Times API'.