### PR TITLE
feat(search-integration): pass category to news apis from search params

### DIFF
--- a/src/lib/actions/article.actions.ts
+++ b/src/lib/actions/article.actions.ts
@@ -6,25 +6,22 @@ import { getNewsApiArticles } from "@/lib/actions/newsApi.actions";
 import { NewsSources } from "@/lib/enums/news.enums";
 import { shuffleArray } from "@/lib/utils";
 
-export const getArticles = async ({
-  page = "1",
-  keyword,
-  fromDate,
-  toDate,
-  newsSource,
-}: {
+export const getArticles = async (searchParams: {
   page?: string;
   keyword?: string;
   fromDate?: string;
   toDate?: string;
   newsSource?: string;
+  category?: string;
 }) => {
+  const { newsSource } = searchParams;
+
   if (!newsSource) {
     const [newsApiArticles, guardianApiArticles, newYorkTimesApiArticles] =
       await Promise.all([
-        getNewsApiArticles({ page, keyword, fromDate, toDate }),
-        getGuardianApiArticles({ page, keyword, fromDate, toDate }),
-        getNewYorkTimesApiArticles({ page, keyword, fromDate, toDate }),
+        getNewsApiArticles(searchParams),
+        getGuardianApiArticles(searchParams),
+        getNewYorkTimesApiArticles(searchParams),
       ]);
 
     const articles = shuffleArray([
@@ -36,7 +33,8 @@ export const getArticles = async ({
     const totalPages =
       Math.max(
         newsApiArticles?.totalPages || 0,
-        guardianApiArticles?.totalPages || 0
+        guardianApiArticles?.totalPages || 0,
+        newYorkTimesApiArticles?.totalPages || 0
       ) || 1;
 
     return {
@@ -47,12 +45,7 @@ export const getArticles = async ({
     switch (newsSource) {
       case NewsSources.NewsAPI:
       default:
-        const newsApiArticles = await getNewsApiArticles({
-          page,
-          keyword,
-          fromDate,
-          toDate,
-        });
+        const newsApiArticles = await getNewsApiArticles(searchParams);
 
         return {
           articles: newsApiArticles?.data || [],
@@ -60,12 +53,7 @@ export const getArticles = async ({
         };
 
       case NewsSources.Guardian:
-        const guardianApiArticles = await getGuardianApiArticles({
-          page,
-          keyword,
-          fromDate,
-          toDate,
-        });
+        const guardianApiArticles = await getGuardianApiArticles(searchParams);
 
         return {
           articles: guardianApiArticles?.data || [],
@@ -73,12 +61,8 @@ export const getArticles = async ({
         };
 
       case NewsSources.NewYorkTimes:
-        const newYorkTimesApiArticles = await getNewYorkTimesApiArticles({
-          page,
-          keyword,
-          fromDate,
-          toDate,
-        });
+        const newYorkTimesApiArticles =
+          await getNewYorkTimesApiArticles(searchParams);
 
         return {
           articles: newYorkTimesApiArticles?.data || [],

--- a/src/lib/actions/guardianApi.actions.ts
+++ b/src/lib/actions/guardianApi.actions.ts
@@ -1,6 +1,10 @@
 "use server";
 
 import { guardianApiClient } from "@/lib/api-clients/guardianApiClient";
+import { DEFAULT_PAGE, PAGE_SIZE } from "@/lib/constants";
+
+const GuardianAPIResponseFormat = "json";
+const GuardianAPIShowFields = "headline,thumbnail,short-url,trailText";
 
 export const getGuardianApiArticles = async ({
   page,
@@ -9,7 +13,7 @@ export const getGuardianApiArticles = async ({
   toDate,
   category,
 }: {
-  page: string;
+  page?: string;
   keyword?: string;
   fromDate?: string;
   toDate?: string;
@@ -30,10 +34,10 @@ export const getGuardianApiArticles = async ({
       };
     }>("/search", {
       params: {
-        page: page || "1",
-        "page-size": 10,
-        format: "json",
-        "show-fields": "headline,thumbnail,short-url,trailText",
+        page: page || DEFAULT_PAGE,
+        "page-size": PAGE_SIZE,
+        format: GuardianAPIResponseFormat,
+        "show-fields": GuardianAPIShowFields,
         q: keyword,
         "form-date": fromDate,
         "to-date": toDate,

--- a/src/lib/actions/newYorkTimesApi.actions.ts
+++ b/src/lib/actions/newYorkTimesApi.actions.ts
@@ -1,6 +1,8 @@
 "use server";
 
 import { newYorkTimesApiClient } from "@/lib/api-clients/newYorkTimesApiClient";
+import { DEFAULT_PAGE, PAGE_SIZE } from "@/lib/constants";
+import { capitalize } from "@/lib/utils";
 
 const NEW_YORK_TIMES_IMAGES_BASE_URL =
   process.env.NEW_YORK_TIMES_IMAGES_BASE_URL;
@@ -10,11 +12,13 @@ export const getNewYorkTimesApiArticles = async ({
   keyword,
   fromDate,
   toDate,
+  category,
 }: {
-  page: string;
+  page?: string;
   keyword?: string;
   fromDate?: string;
   toDate?: string;
+  category?: string;
 }) => {
   try {
     const response = await newYorkTimesApiClient.get<{
@@ -30,10 +34,11 @@ export const getNewYorkTimesApiArticles = async ({
       };
     }>("/articlesearch.json", {
       params: {
-        page: page || "1",
+        page: Number(page) - 1 || DEFAULT_PAGE - 1,
         q: keyword,
-        begin_date: fromDate,
-        end_date: toDate,
+        begin_date: fromDate?.replaceAll("-", ""),
+        end_date: toDate?.replaceAll("-", ""),
+        section_name: category ? capitalize(category) : undefined,
       },
     });
 
@@ -48,7 +53,7 @@ export const getNewYorkTimesApiArticles = async ({
             url: web_url,
           })
         ) || [],
-      totalPages: response.data.response.meta.hits,
+      totalPages: Math.ceil(response.data.response.meta.hits / PAGE_SIZE),
     };
   } catch (e) {
     console.error(e);

--- a/src/lib/actions/newsApi.actions.ts
+++ b/src/lib/actions/newsApi.actions.ts
@@ -1,18 +1,29 @@
 "use server";
 
 import { newsApiClient } from "@/lib/api-clients/newsApiClient";
+import { DEFAULT_PAGE, PAGE_SIZE } from "@/lib/constants";
+
+const NewsAPISources = "bbc-news, new-york-magazine, bloomberg, abc-news";
 
 export const getNewsApiArticles = async ({
   page,
   keyword,
   fromDate,
   toDate,
+  category,
 }: {
-  page: string;
+  page?: string;
   keyword?: string;
   fromDate?: string;
   toDate?: string;
+  category?: string;
 }) => {
+  let query = keyword;
+
+  if (category) {
+    query += ` AND ${category}`;
+  }
+
   try {
     const response = await newsApiClient.get<{
       status: string;
@@ -20,10 +31,10 @@ export const getNewsApiArticles = async ({
       articles: NewsAPIArticle[];
     }>("/everything", {
       params: {
-        page: page || "1",
-        sources: "bbc-news, new-york-magazine, bloomberg, abc-news",
-        pageSize: 10,
-        q: keyword,
+        page: page || DEFAULT_PAGE,
+        sources: NewsAPISources,
+        pageSize: PAGE_SIZE,
+        q: query,
         from: fromDate,
         to: toDate,
       },

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,9 @@
 import { Categories, NewsSources } from "@/lib/enums/news.enums";
 
+export const PAGE_SIZE = 10;
+
+export const DEFAULT_PAGE = 1;
+
 export const NEWS_SOURCES = [
   {
     label: "All Source",
@@ -35,5 +39,21 @@ export const CATEGORIES = [
   {
     label: "Sports",
     value: Categories.Sports,
+  },
+  {
+    label: "News",
+    value: Categories.News,
+  },
+  {
+    label: "Science",
+    value: Categories.Science,
+  },
+  {
+    label: "Fashion",
+    value: Categories.Fashion,
+  },
+  {
+    label: "Environment",
+    value: Categories.Environment,
   },
 ] as { label: string; value: string }[];

--- a/src/lib/enums/news.enums.ts
+++ b/src/lib/enums/news.enums.ts
@@ -9,6 +9,10 @@ export const enum Categories {
   Politics = "politics",
   Technology = "technology",
   Sports = "sports",
+  News = "news",
+  Science = "science",
+  Fashion = "fashion",
+  Environment = "environment",
 }
 
 export const enum SearchArticlesFormFields {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -38,3 +38,7 @@ export const shuffleArray = <T>(array: T[]): T[] => {
   }
   return array;
 };
+
+export const capitalize = (word: string) => {
+  return word.substring(0, 1).toUpperCase() + word.substring(1).toLowerCase();
+};


### PR DESCRIPTION
- Implemented passing category from search parameters to the Guardian, New York Times, and News API to filter news results by category.