### PR TITLE
feat(news-feed): implement personalized news feed page

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -1,22 +1,43 @@
-import ArticleCard from "@/components/cards/ArticleCard";
-import { ArticleCardsContainer } from "@/components/containers/ArticleCardsContainer";
+import { Suspense } from "react";
 
-export default function FeedPage() {
+import PersonalizedArticlesSection from "@/components/containers/PersonalizedArticlesSection";
+import SearchPersonalizedNewsFeedForm from "@/components/forms/SearchPersonalizedNewsFeedForm";
+import ArticlesSectionSkeletonUI from "@/components/ui/ArticlesSectionSkeletonUI";
+
+export default function FeedPage({
+  searchParams,
+}: {
+  searchParams: {
+    page?: string;
+    newsSource?: string;
+    category?: string;
+    authors?: string;
+  };
+}) {
+  const urlSearchParams = new URLSearchParams(
+    Object.entries(searchParams)
+  ).toString();
+
+  const newsSources = searchParams ? searchParams.newsSource?.split(",") : [];
+  const categories = searchParams ? searchParams.category?.split(",") : [];
+  const authors = searchParams ? searchParams.authors?.split(",") : [];
+
   return (
     <main className="container mx-auto px-4 py-8">
+      <SearchPersonalizedNewsFeedForm />
+
       <h2 className="mb-6 text-2xl font-bold">Your Personalized News Feed</h2>
 
       <div className="mb-8">
         <h3 className="mb-4 text-xl font-semibold">Top Stories for You</h3>
-        <ArticleCardsContainer>
-          <ArticleCard />
-          <ArticleCard />
-          <ArticleCard />
-          <ArticleCard />
-          <ArticleCard />
-          <ArticleCard />
-          <ArticleCard />
-        </ArticleCardsContainer>
+        <Suspense
+          key={urlSearchParams}
+          fallback={<ArticlesSectionSkeletonUI />}
+        >
+          <PersonalizedArticlesSection
+            {...{ page: searchParams.page, newsSources, categories, authors }}
+          />
+        </Suspense>
       </div>
     </main>
   );

--- a/src/components/containers/PersonalizedArticlesSection.tsx
+++ b/src/components/containers/PersonalizedArticlesSection.tsx
@@ -1,0 +1,26 @@
+import ArticleCard from "@/components/cards/ArticleCard";
+import { ArticleCardsContainer } from "@/components/containers/ArticleCardsContainer";
+import Pagination from "@/components/ui/Pagination";
+import { getFeedArticles } from "@/lib/actions/feed.actions";
+
+const PersonalizedArticlesSection = async (searchParams: {
+  page?: string;
+  newsSources?: string[];
+  categories?: string[];
+  authors?: string[];
+}) => {
+  const { articles, totalPages } = await getFeedArticles(searchParams);
+
+  return (
+    <>
+      <ArticleCardsContainer>
+        {articles?.map((article, index) => (
+          <ArticleCard key={`article-${index}`} {...article} />
+        ))}
+      </ArticleCardsContainer>
+      <Pagination totalPages={totalPages} />
+    </>
+  );
+};
+
+export default PersonalizedArticlesSection;

--- a/src/components/forms/PersonalizedNewsFeedForm.tsx
+++ b/src/components/forms/PersonalizedNewsFeedForm.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { useCallback } from "react";
 import { FormProvider, useForm } from "react-hook-form";
+
+import { useRouter } from "next/navigation";
 
 import Button from "@/components/ui/Button";
 import Dropdown from "@/components/ui/Dropdown";
@@ -8,16 +11,43 @@ import Input from "@/components/ui/Input";
 import { CATEGORIES_OPTIONS, NEWS_SOURCES_OPTIONS } from "@/lib/constants";
 import { LocalStorageKeys, PersonalizedNewsFeedFormFields } from "@/lib/enums";
 import { PersonalizedNewsFeedFormSchema } from "@/lib/schemas";
+import { PersonalizedNewsFeed } from "@/lib/types";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 const PersonalizedNewsFeedForm = () => {
+  const { replace } = useRouter();
+
+  const getFormDefaultValues = useCallback(() => {
+    const personalizedNewsFeedPreferences = localStorage.getItem(
+      LocalStorageKeys.personalizedNewsFeedPreferences
+    );
+    let personalizedNewsFeed: PersonalizedNewsFeed =
+      personalizedNewsFeedPreferences
+        ? JSON.parse(personalizedNewsFeedPreferences)
+        : {
+            [PersonalizedNewsFeedFormFields.preferredNewsSources]: [],
+            [PersonalizedNewsFeedFormFields.preferredCategories]: [],
+            [PersonalizedNewsFeedFormFields.preferredAuthors]: "",
+          };
+
+    return {
+      [PersonalizedNewsFeedFormFields.preferredNewsSources]:
+        personalizedNewsFeed[
+          PersonalizedNewsFeedFormFields.preferredNewsSources
+        ] || [],
+      [PersonalizedNewsFeedFormFields.preferredCategories]:
+        personalizedNewsFeed[
+          PersonalizedNewsFeedFormFields.preferredCategories
+        ] || [],
+      [PersonalizedNewsFeedFormFields.preferredAuthors]:
+        personalizedNewsFeed[PersonalizedNewsFeedFormFields.preferredAuthors] ||
+        "",
+    };
+  }, []);
+
   const personalizedNewsFeedForm = useForm({
     resolver: zodResolver(PersonalizedNewsFeedFormSchema),
-    defaultValues: {
-      [PersonalizedNewsFeedFormFields.preferredNewsSources]: [],
-      [PersonalizedNewsFeedFormFields.preferredCategories]: [],
-      [PersonalizedNewsFeedFormFields.preferredAuthors]: "",
-    },
+    defaultValues: getFormDefaultValues(),
   });
 
   const { register, handleSubmit } = personalizedNewsFeedForm;
@@ -28,6 +58,7 @@ const PersonalizedNewsFeedForm = () => {
         LocalStorageKeys.personalizedNewsFeedPreferences,
         JSON.stringify(formData)
       );
+      replace("/feed");
     },
     (error) => console.error(error)
   );

--- a/src/components/forms/SearchPersonalizedNewsFeedForm.tsx
+++ b/src/components/forms/SearchPersonalizedNewsFeedForm.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import { z } from "zod";
+
+import { LocalStorageKeys, PersonalizedNewsFeedFormFields } from "@/lib/enums";
+import { PersonalizedNewsFeedFormSchema } from "@/lib/schemas";
+
+type PersonalizedNewsFeed = z.infer<typeof PersonalizedNewsFeedFormSchema>;
+
+const SearchPersonalizedNewsFeedForm = () => {
+  const searchParams = useSearchParams();
+  const { replace } = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const personalizedNewsFeedPreferences = localStorage.getItem(
+      LocalStorageKeys.personalizedNewsFeedPreferences
+    );
+
+    if (!personalizedNewsFeedPreferences) {
+      replace("/settings");
+    }
+
+    if (personalizedNewsFeedPreferences) {
+      const personalizedNewsFeed: PersonalizedNewsFeed = JSON.parse(
+        personalizedNewsFeedPreferences
+      );
+      const params = new URLSearchParams(searchParams);
+
+      if (
+        personalizedNewsFeed[
+          PersonalizedNewsFeedFormFields.preferredNewsSources
+        ]
+      ) {
+        params.set(
+          "newsSource",
+          personalizedNewsFeed[
+            PersonalizedNewsFeedFormFields.preferredNewsSources
+          ].join(",")
+        );
+      } else params.delete("newsSource");
+
+      if (
+        personalizedNewsFeed[PersonalizedNewsFeedFormFields.preferredCategories]
+      ) {
+        params.set(
+          "category",
+          personalizedNewsFeed[
+            PersonalizedNewsFeedFormFields.preferredCategories
+          ].join(",")
+        );
+      } else params.delete("category");
+
+      if (
+        personalizedNewsFeed[PersonalizedNewsFeedFormFields.preferredAuthors]
+      ) {
+        params.set(
+          "authors",
+          personalizedNewsFeed[PersonalizedNewsFeedFormFields.preferredAuthors]
+        );
+      } else params.delete("authors");
+
+      params.set("page", "1");
+
+      replace(`${pathname}?${params.toString()}`);
+    }
+  }, [pathname, replace, searchParams]);
+
+  return null;
+};
+
+export default SearchPersonalizedNewsFeedForm;

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -1,0 +1,6 @@
+/* eslint-disable no-unused-vars */
+import { z } from "zod";
+
+import { PersonalizedNewsFeedFormSchema } from "@/lib/schemas";
+
+type PersonalizedNewsFeed = z.infer<typeof PersonalizedNewsFeedFormSchema>;


### PR DESCRIPTION
- Created the '/feed' page UI for displaying personalized news content.
- Implemented functionality to fetch and display news articles based on user preferences.
- Added a mechanism to save user preferences and redirect to '/feed' after saving.