### PR TITLE
feat(news-feed): save and load personalized news feed preferences

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -1,8 +1,11 @@
 import { Suspense } from "react";
 
+import { cookies } from "next/headers";
+
 import PersonalizedArticlesSection from "@/components/containers/PersonalizedArticlesSection";
 import SearchPersonalizedNewsFeedForm from "@/components/forms/SearchPersonalizedNewsFeedForm";
 import ArticlesSectionSkeletonUI from "@/components/ui/ArticlesSectionSkeletonUI";
+import { CookiesKeys } from "@/lib/enums";
 
 export default function FeedPage({
   searchParams,
@@ -18,26 +21,36 @@ export default function FeedPage({
     Object.entries(searchParams)
   ).toString();
 
+  const personalizedNewsFeedPreferences = cookies().get(
+    CookiesKeys.personalizedNewsFeedPreferences
+  )?.value;
+
   const newsSources = searchParams ? searchParams.newsSource?.split(",") : [];
   const categories = searchParams ? searchParams.category?.split(",") : [];
   const authors = searchParams ? searchParams.authors?.split(",") : [];
 
   return (
     <main className="container mx-auto px-4 py-8">
-      <SearchPersonalizedNewsFeedForm />
+      <SearchPersonalizedNewsFeedForm
+        personalizedNewsFeedPreferences={personalizedNewsFeedPreferences}
+      />
 
       <h2 className="mb-6 text-2xl font-bold">Your Personalized News Feed</h2>
 
       <div className="mb-8">
         <h3 className="mb-4 text-xl font-semibold">Top Stories for You</h3>
-        <Suspense
-          key={urlSearchParams}
-          fallback={<ArticlesSectionSkeletonUI />}
-        >
-          <PersonalizedArticlesSection
-            {...{ page: searchParams.page, newsSources, categories, authors }}
-          />
-        </Suspense>
+        {urlSearchParams ? (
+          <Suspense
+            key={urlSearchParams}
+            fallback={<ArticlesSectionSkeletonUI />}
+          >
+            <PersonalizedArticlesSection
+              {...{ page: searchParams.page, newsSources, categories, authors }}
+            />
+          </Suspense>
+        ) : (
+          <ArticlesSectionSkeletonUI />
+        )}
       </div>
     </main>
   );

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,12 +1,21 @@
+import { cookies } from "next/headers";
+
 import PersonalizedNewsFeedForm from "@/components/forms/PersonalizedNewsFeedForm";
+import { CookiesKeys } from "@/lib/enums";
 
 export default function SettingsPage() {
+  const personalizedNewsFeedPreferences = cookies().get(
+    CookiesKeys.personalizedNewsFeedPreferences
+  )?.value;
+
   return (
     <main className="container mx-auto px-4 py-8">
       <h2 className="mb-8 text-2xl font-bold">
         Personalized News Feed Settings
       </h2>
-      <PersonalizedNewsFeedForm />
+      <PersonalizedNewsFeedForm
+        personalizedNewsFeedPreferences={personalizedNewsFeedPreferences}
+      />
     </main>
   );
 }

--- a/src/components/forms/SearchPersonalizedNewsFeedForm.tsx
+++ b/src/components/forms/SearchPersonalizedNewsFeedForm.tsx
@@ -4,71 +4,32 @@ import { useEffect } from "react";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
-import { z } from "zod";
-
-import { LocalStorageKeys, PersonalizedNewsFeedFormFields } from "@/lib/enums";
-import { PersonalizedNewsFeedFormSchema } from "@/lib/schemas";
-
-type PersonalizedNewsFeed = z.infer<typeof PersonalizedNewsFeedFormSchema>;
-
-const SearchPersonalizedNewsFeedForm = () => {
+const SearchPersonalizedNewsFeedForm = ({
+  personalizedNewsFeedPreferences,
+}: {
+  personalizedNewsFeedPreferences?: string;
+}) => {
   const searchParams = useSearchParams();
   const { replace } = useRouter();
   const pathname = usePathname();
 
   useEffect(() => {
-    const personalizedNewsFeedPreferences = localStorage.getItem(
-      LocalStorageKeys.personalizedNewsFeedPreferences
-    );
+    if (personalizedNewsFeedPreferences) {
+      if (
+        !searchParams.has("newsSource") &&
+        !searchParams.has("category") &&
+        !searchParams.has("authors")
+      ) {
+        const params = new URLSearchParams(personalizedNewsFeedPreferences);
 
-    if (!personalizedNewsFeedPreferences) {
+        params.set("page", "1");
+
+        replace(`${pathname}?${params.toString()}`);
+      }
+    } else {
       replace("/settings");
     }
-
-    if (personalizedNewsFeedPreferences) {
-      const personalizedNewsFeed: PersonalizedNewsFeed = JSON.parse(
-        personalizedNewsFeedPreferences
-      );
-      const params = new URLSearchParams(searchParams);
-
-      if (
-        personalizedNewsFeed[
-          PersonalizedNewsFeedFormFields.preferredNewsSources
-        ]
-      ) {
-        params.set(
-          "newsSource",
-          personalizedNewsFeed[
-            PersonalizedNewsFeedFormFields.preferredNewsSources
-          ].join(",")
-        );
-      } else params.delete("newsSource");
-
-      if (
-        personalizedNewsFeed[PersonalizedNewsFeedFormFields.preferredCategories]
-      ) {
-        params.set(
-          "category",
-          personalizedNewsFeed[
-            PersonalizedNewsFeedFormFields.preferredCategories
-          ].join(",")
-        );
-      } else params.delete("category");
-
-      if (
-        personalizedNewsFeed[PersonalizedNewsFeedFormFields.preferredAuthors]
-      ) {
-        params.set(
-          "authors",
-          personalizedNewsFeed[PersonalizedNewsFeedFormFields.preferredAuthors]
-        );
-      } else params.delete("authors");
-
-      params.set("page", "1");
-
-      replace(`${pathname}?${params.toString()}`);
-    }
-  }, [pathname, replace, searchParams]);
+  }, [pathname, personalizedNewsFeedPreferences, replace, searchParams]);
 
   return null;
 };

--- a/src/lib/actions/feed.actions.ts
+++ b/src/lib/actions/feed.actions.ts
@@ -1,11 +1,25 @@
 "use server";
 
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
 import { getGuardianApiArticles } from "@/lib/actions/guardianApi.actions";
 import { getNewYorkTimesApiArticles } from "@/lib/actions/newYorkTimesApi.actions";
 import { getNewsApiArticles } from "@/lib/actions/newsApi.actions";
-import { NewsSources } from "@/lib/enums";
+import { CookiesKeys, NewsSources } from "@/lib/enums";
 import { ArticleAPIResponse } from "@/lib/types";
 import { shuffleArray } from "@/lib/utils";
+
+export const setPersonalizedFeedPrefrences = async (
+  personalizedNewsFeed: string
+) => {
+  cookies().set(
+    CookiesKeys.personalizedNewsFeedPreferences,
+    personalizedNewsFeed,
+    { httpOnly: true, path: "/" }
+  );
+  redirect("/feed");
+};
 
 export const getFeedArticles = async (searchParams: {
   page?: string;

--- a/src/lib/enums.ts
+++ b/src/lib/enums.ts
@@ -30,8 +30,8 @@ export const enum PersonalizedNewsFeedFormFields {
   preferredAuthors = "preferred-authors",
 }
 
-export const enum LocalStorageKeys {
-  personalizedNewsFeedPreferences = "personalizedNewsFeedPreferences",
+export const enum CookiesKeys {
+  personalizedNewsFeedPreferences = "personalized-news-feed-preferences",
 }
 
 export const enum DateFormats {


### PR DESCRIPTION
- Added functionality to save personalized news feed preferences in cookies upon form submission.
- Implemented logic to parse and load preferences from cookies on '/feed' and '/settings' pages.