### PR TITLE
feat(articles-api): add unique id to articles

### DIFF
--- a/src/components/containers/ArticlesSection.tsx
+++ b/src/components/containers/ArticlesSection.tsx
@@ -16,8 +16,8 @@ const ArticlesSection = async (searchParams: {
   return (
     <>
       <ArticleCardsContainer>
-        {articles?.map((article, index) => (
-          <ArticleCard key={`article-${index}`} {...article} />
+        {articles?.map((article) => (
+          <ArticleCard key={article.id} {...article} />
         ))}
       </ArticleCardsContainer>
       <Pagination totalPages={totalPages} />

--- a/src/components/containers/PersonalizedArticlesSection.tsx
+++ b/src/components/containers/PersonalizedArticlesSection.tsx
@@ -14,8 +14,8 @@ const PersonalizedArticlesSection = async (searchParams: {
   return (
     <>
       <ArticleCardsContainer>
-        {articles?.map((article, index) => (
-          <ArticleCard key={`article-${index}`} {...article} />
+        {articles?.map((article) => (
+          <ArticleCard key={article.id} {...article} />
         ))}
       </ArticleCardsContainer>
       <Pagination totalPages={totalPages} />

--- a/src/lib/actions/guardianApi.actions.ts
+++ b/src/lib/actions/guardianApi.actions.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { randomUUID } from "crypto";
+
 import { guardianApiClient } from "@/lib/api-clients/guardianApiClient";
 import { DEFAULT_PAGE, PAGE_SIZE } from "@/lib/constants";
 
@@ -50,6 +52,7 @@ export const getGuardianApiArticles = async ({
       data:
         response.data?.response.results.map(
           ({ fields, webPublicationDate, sectionName }) => ({
+            id: randomUUID(),
             title: fields.headline,
             description: fields.trailText,
             imageUrl: fields.thumbnail,

--- a/src/lib/actions/newYorkTimesApi.actions.ts
+++ b/src/lib/actions/newYorkTimesApi.actions.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { randomUUID } from "crypto";
+
 import { newYorkTimesApiClient } from "@/lib/api-clients/newYorkTimesApiClient";
 import { DEFAULT_PAGE, PAGE_SIZE } from "@/lib/constants";
 
@@ -55,6 +57,7 @@ export const getNewYorkTimesApiArticles = async ({
             pub_date,
             section_name,
           }) => ({
+            id: randomUUID(),
             title: headline.main,
             description: abstract,
             imageUrl: `${NEW_YORK_TIMES_IMAGES_BASE_URL}${multimedia?.[0]?.url}`,

--- a/src/lib/actions/newsApi.actions.ts
+++ b/src/lib/actions/newsApi.actions.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { randomUUID } from "crypto";
+
 import { newsApiClient } from "@/lib/api-clients/newsApiClient";
 import { DEFAULT_PAGE, PAGE_SIZE } from "@/lib/constants";
 
@@ -48,6 +50,7 @@ export const getNewsApiArticles = async ({
       data:
         response?.data?.articles.map(
           ({ title, description, urlToImage, source, url, publishedAt }) => ({
+            id: randomUUID(),
             title,
             description,
             imageUrl: urlToImage,

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -6,6 +6,7 @@ import { PersonalizedNewsFeedFormSchema } from "@/lib/schemas";
 type PersonalizedNewsFeed = z.infer<typeof PersonalizedNewsFeedFormSchema>;
 
 type Article = {
+  id: string;
   title: string;
   description: string;
   imageUrl: string;


### PR DESCRIPTION
- Implemented UUID generation using Node.js crypto module to assign a unique ID to each article.
- Added the generated UUID as 'id' field in the articles API response.
- Modified the frontend rendering logic to use the 'id' as key in the map for efficient article rendering.