### PR TITLE
refactor(news-api-handling): use promise.allsettled for news api requests

### DIFF
--- a/src/components/containers/ArticlesSection.tsx
+++ b/src/components/containers/ArticlesSection.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import ArticleCard from "@/components/cards/ArticleCard";
 import { ArticleCardsContainer } from "@/components/containers/ArticleCardsContainer";
 import Pagination from "@/components/ui/Pagination";
@@ -11,7 +13,7 @@ const ArticlesSection = async (searchParams: {
   newsSource?: string;
   category?: string;
 }) => {
-  const { articles, totalPages } = await getArticles(searchParams);
+  const { articles, totalPages, error } = await getArticles(searchParams);
 
   return (
     <>
@@ -20,6 +22,16 @@ const ArticlesSection = async (searchParams: {
           <ArticleCard key={article.id} {...article} />
         ))}
       </ArticleCardsContainer>
+      {!articles?.length && error ? (
+        <div>
+          {error}{" "}
+          <Link href="/" className="inline-block text-blue-500 hover:underline">
+            Reset
+          </Link>
+        </div>
+      ) : (
+        <p>No Article Found</p>
+      )}
       <Pagination totalPages={totalPages} />
     </>
   );

--- a/src/lib/actions/article.actions.ts
+++ b/src/lib/actions/article.actions.ts
@@ -17,12 +17,59 @@ export const getArticles = async (searchParams: {
   const { newsSource } = searchParams;
 
   if (!newsSource) {
-    const [newsApiArticles, guardianApiArticles, newYorkTimesApiArticles] =
-      await Promise.all([
+    const [newsAPIResult, guardianAPIResult, newYorkTimesAPIResult] =
+      await Promise.allSettled([
         getNewsApiArticles(searchParams),
         getGuardianApiArticles(searchParams),
         getNewYorkTimesApiArticles(searchParams),
       ]);
+
+    const newsApiArticles =
+      newsAPIResult?.status === "fulfilled" && newsAPIResult?.value
+        ? {
+            data: newsAPIResult.value.data,
+            totalPages: newsAPIResult.value.totalPages,
+            error: newsAPIResult.value.error,
+          }
+        : {
+            data: [],
+            totalPages: 0,
+            error:
+              newsAPIResult.status === "rejected"
+                ? newsAPIResult.reason
+                : undefined,
+          };
+    const guardianApiArticles =
+      guardianAPIResult?.status === "fulfilled" && guardianAPIResult?.value
+        ? {
+            data: guardianAPIResult.value.data,
+            totalPages: guardianAPIResult.value.totalPages,
+            error: guardianAPIResult.value.error,
+          }
+        : {
+            data: [],
+            totalPages: 0,
+            error:
+              guardianAPIResult.status === "rejected"
+                ? guardianAPIResult.reason
+                : undefined,
+          };
+    const newYorkTimesApiArticles =
+      newYorkTimesAPIResult?.status === "fulfilled" &&
+      newYorkTimesAPIResult?.value
+        ? {
+            data: newYorkTimesAPIResult.value.data,
+            totalPages: newYorkTimesAPIResult.value.totalPages,
+            error: newYorkTimesAPIResult.value.error,
+          }
+        : {
+            data: [],
+            totalPages: 0,
+            error:
+              newYorkTimesAPIResult.status === "rejected"
+                ? newYorkTimesAPIResult.reason
+                : undefined,
+          };
 
     const articles = shuffleArray([
       ...(newsApiArticles?.data || []),
@@ -37,9 +84,17 @@ export const getArticles = async (searchParams: {
         newYorkTimesApiArticles?.totalPages || 0
       ) || 1;
 
+    const errors: string[] = [];
+
+    if (newsApiArticles.error) errors.push(newsApiArticles.error);
+    if (guardianApiArticles.error) errors.push(guardianApiArticles.error);
+    if (newYorkTimesApiArticles.error)
+      errors.push(newYorkTimesApiArticles.error);
+
     return {
       articles,
       totalPages,
+      error: errors.join("\n"),
     };
   } else {
     switch (newsSource) {
@@ -50,6 +105,7 @@ export const getArticles = async (searchParams: {
         return {
           articles: newsApiArticles?.data || [],
           totalPages: newsApiArticles?.totalPages || 1,
+          error: newsApiArticles?.error,
         };
 
       case NewsSources.Guardian:
@@ -58,6 +114,7 @@ export const getArticles = async (searchParams: {
         return {
           articles: guardianApiArticles?.data || [],
           totalPages: guardianApiArticles?.totalPages || 1,
+          error: guardianApiArticles?.error,
         };
 
       case NewsSources.NewYorkTimes:
@@ -67,6 +124,7 @@ export const getArticles = async (searchParams: {
         return {
           articles: newYorkTimesApiArticles?.data || [],
           totalPages: newYorkTimesApiArticles?.totalPages || 1,
+          error: newYorkTimesApiArticles?.error,
         };
     }
   }

--- a/src/lib/actions/guardianApi.actions.ts
+++ b/src/lib/actions/guardianApi.actions.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "crypto";
 
 import { guardianApiClient } from "@/lib/api-clients/guardianApiClient";
 import { DEFAULT_PAGE, PAGE_SIZE } from "@/lib/constants";
+import { getErrorMessage } from "@/lib/utils";
 
 const GuardianAPIResponseFormat = "json";
 const GuardianAPIShowFields =
@@ -64,7 +65,10 @@ export const getGuardianApiArticles = async ({
         ) || [],
       totalPages: response.data.response.pages,
     };
-  } catch (e) {
-    console.error(e);
+  } catch (error) {
+    console.error(error);
+    return {
+      error: getErrorMessage(error),
+    };
   }
 };

--- a/src/lib/actions/newYorkTimesApi.actions.ts
+++ b/src/lib/actions/newYorkTimesApi.actions.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "crypto";
 
 import { newYorkTimesApiClient } from "@/lib/api-clients/newYorkTimesApiClient";
 import { DEFAULT_PAGE, PAGE_SIZE } from "@/lib/constants";
+import { getErrorMessage } from "@/lib/utils";
 
 const NEW_YORK_TIMES_IMAGES_BASE_URL =
   process.env.NEW_YORK_TIMES_IMAGES_BASE_URL;
@@ -69,7 +70,10 @@ export const getNewYorkTimesApiArticles = async ({
         ) || [],
       totalPages: Math.ceil(response.data.response.meta.hits / PAGE_SIZE),
     };
-  } catch (e) {
-    console.error(e);
+  } catch (error) {
+    console.error(error);
+    return {
+      error: getErrorMessage(error),
+    };
   }
 };

--- a/src/lib/actions/newsApi.actions.ts
+++ b/src/lib/actions/newsApi.actions.ts
@@ -4,8 +4,9 @@ import { randomUUID } from "crypto";
 
 import { newsApiClient } from "@/lib/api-clients/newsApiClient";
 import { DEFAULT_PAGE, PAGE_SIZE } from "@/lib/constants";
+import { getErrorMessage } from "@/lib/utils";
 
-const NewsAPISources = "bbc-news, new-york-magazine, bloomberg, abc-news";
+const NewsAPISources = "bbc-news,new-york-magazine,bloomberg,abc-news";
 
 export const getNewsApiArticles = async ({
   page,
@@ -62,7 +63,10 @@ export const getNewsApiArticles = async ({
         ) || [],
       totalPages: response.data.totalResults,
     };
-  } catch (e) {
-    console.error(e);
+  } catch (error) {
+    console.error(error);
+    return {
+      error: getErrorMessage(error),
+    };
   }
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -42,3 +42,19 @@ export const shuffleArray = <T>(array: T[]): T[] => {
 export const capitalize = (word: string) => {
   return word.substring(0, 1).toUpperCase() + word.substring(1).toLowerCase();
 };
+
+export const getErrorMessage = (error: unknown): string => {
+  let message: string;
+
+  if (error instanceof Error) {
+    message = error.message;
+  } else if (error && typeof error === "object" && "message" in error) {
+    message = String(error.message);
+  } else if (typeof error === "string") {
+    message = error;
+  } else {
+    message = "Something went wrong";
+  }
+
+  return message;
+};


### PR DESCRIPTION
- Replaced 'Promise.all' with 'Promise.allSettled' for handling news API requests.
- This allows displaying articles if at least one API call succeeds, even if others fail.
- Implemented logic to display an error message if all API responses are unsuccessful and the articles list is empty.