### PR TITLE
feat(article-details): add article details page and modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "news-aggregator",
       "version": "1.0.0",
       "dependencies": {
+        "@heroicons/react": "^2.1.5",
         "@hookform/resolvers": "^3.9.0",
         "axios": "^1.7.7",
         "dayjs": "^1.11.13",
@@ -477,6 +478,14 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.1.5.tgz",
+      "integrity": "sha512-FuzFN+BsHa+7OxbvAERtgBTNeZpUjgM/MIizfVkSCL2/edriN0Hx/DWRCR//aPYwO5QX/YlgLGXk+E3PcfZwjA==",
+      "peerDependencies": {
+        "react": ">= 16"
       }
     },
     "node_modules/@hookform/resolvers": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@heroicons/react": "^2.1.5",
     "@hookform/resolvers": "^3.9.0",
     "axios": "^1.7.7",
     "dayjs": "^1.11.13",

--- a/src/app/@modal/(.)article/loading.tsx
+++ b/src/app/@modal/(.)article/loading.tsx
@@ -1,0 +1,26 @@
+export default function ArticleModalLoader() {
+  return (
+    <div className="w-full max-w-4xl animate-pulse rounded-lg bg-white p-6 shadow-xl">
+      <div className="mb-4 flex items-start justify-between">
+        <div className="h-8 w-3/4 rounded bg-gray-300" />
+        <div className="size-6 rounded-full bg-gray-300" />
+      </div>
+      <div className="mb-6 flex flex-wrap gap-4">
+        {[...Array(4)].map((_, index) => (
+          <div key={index} className="flex items-center">
+            <div className="mr-2 size-5 rounded-full bg-gray-300" />
+            <div className="h-5 w-20 rounded bg-gray-300" />
+          </div>
+        ))}
+      </div>
+      <div className="mb-6 space-y-4">
+        {[...Array(6)].map((_, index) => (
+          <div key={index} className="h-4 w-full rounded bg-gray-300" />
+        ))}
+      </div>
+      <div className="flex justify-end">
+        <div className="h-10 w-32 rounded bg-gray-300" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/@modal/(.)article/page.tsx
+++ b/src/app/@modal/(.)article/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { useRouter } from "next/navigation";
+
+import ArticleDetails from "@/components/cards/ArticleDetails";
+import { useArticle } from "@/contexts/ArticleContext";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+
+export default function ArticleModal() {
+  const router = useRouter();
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const { selectedArticle, setSelectedArticle } = useArticle();
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog && selectedArticle) {
+      dialog.showModal();
+    }
+  }, [selectedArticle]);
+
+  const handleClose = () => {
+    setSelectedArticle(null);
+    router.back();
+  };
+
+  if (!selectedArticle) return null;
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="w-full max-w-4xl rounded-lg bg-white p-6 shadow-xl"
+    >
+      <div className="mb-4 flex items-start justify-between">
+        <h2 className="text-2xl font-bold">{selectedArticle.title}</h2>
+        <button
+          onClick={handleClose}
+          className="rounded-full p-1 text-gray-500 transition-colors duration-200 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          aria-label="Close dialog"
+        >
+          <XMarkIcon className="size-6" />
+        </button>
+      </div>
+      <ArticleDetails article={selectedArticle} showFullContent={true} />
+      <div className="mt-6 flex justify-end">
+        <a
+          href={selectedArticle.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded bg-blue-500 px-4 py-2 text-white transition duration-300 hover:bg-blue-600"
+        >
+          Read Full Article
+        </a>
+      </div>
+    </dialog>
+  );
+}

--- a/src/app/@modal/default.tsx
+++ b/src/app/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/src/app/article/loading.tsx
+++ b/src/app/article/loading.tsx
@@ -1,0 +1,24 @@
+export default function ArticlePageLoader() {
+  return (
+    <div className="mx-auto max-w-4xl animate-pulse p-6">
+      <div className="mb-6 h-10 w-3/4 rounded bg-gray-300" />
+      <div className="mb-6 flex flex-wrap gap-4">
+        {[...Array(4)].map((_, index) => (
+          <div key={index} className="flex items-center">
+            <div className="mr-2 size-5 rounded-full bg-gray-300" />
+            <div className="h-5 w-20 rounded bg-gray-300" />
+          </div>
+        ))}
+      </div>
+      <div className="mb-6 space-y-4">
+        {[...Array(10)].map((_, index) => (
+          <div key={index} className="h-4 w-full rounded bg-gray-300" />
+        ))}
+      </div>
+      <div className="flex items-center justify-between">
+        <div className="h-10 w-24 rounded bg-gray-300" />
+        <div className="h-10 w-32 rounded bg-gray-300" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/article/page.tsx
+++ b/src/app/article/page.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect } from "react";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import ArticleDetails from "@/components/cards/ArticleDetails";
+import { useArticle } from "@/contexts/ArticleContext";
+
+export default function ArticlePage() {
+  const { selectedArticle } = useArticle();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!selectedArticle) {
+      router.push("/");
+    }
+  }, [selectedArticle, router]);
+
+  if (!selectedArticle) return null;
+
+  return (
+    <div className="mx-auto max-w-4xl p-6">
+      <ArticleDetails article={selectedArticle} showFullContent={true} />
+      <div className="mt-6 flex items-center justify-between">
+        <Link href="/" className="text-blue-500 hover:underline">
+          ← Back to Home
+        </Link>
+        <a
+          href={selectedArticle.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded bg-blue-500 px-4 py-2 text-white transition duration-300 hover:bg-blue-600"
+        >
+          Read Full Article
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 
 import Footer from "@/components/ui/Footer";
 import Header from "@/components/ui/Header";
+import { ArticleProvider } from "@/contexts/ArticleContext";
 
 import "./globals.css";
 
@@ -12,15 +13,20 @@ export const metadata: Metadata = {
 
 export default function RootLayout({
   children,
+  modal,
 }: Readonly<{
   children: React.ReactNode;
+  modal: React.ReactNode;
 }>) {
   return (
     <html lang="en">
       <body className="bg-gray-100">
-        <Header />
-        {children}
-        <Footer />
+        <ArticleProvider>
+          <Header />
+          {children}
+          <Footer />
+          {modal}
+        </ArticleProvider>
       </body>
     </html>
   );

--- a/src/components/cards/ArticleCard.tsx
+++ b/src/components/cards/ArticleCard.tsx
@@ -1,55 +1,30 @@
 import Image from "next/image";
-import Link from "next/link";
 
-import dayjs from "dayjs";
-
-import { DateFormats } from "@/lib/enums";
+import ArticleDetails from "@/components/cards/ArticleDetails";
+import ReadMoreLink from "@/components/ui/ReadMoreLink";
 import { Article } from "@/lib/types";
 
-const ArticleCard = ({
-  title,
-  description,
-  imageUrl,
-  source,
-  url,
-  date,
-  category,
-}: Article) => {
+const ArticleCard = (article: Article) => {
+  const { imageUrl, title } = article;
   return (
     <article className="flex flex-col overflow-hidden rounded-lg bg-white shadow-md">
-      <Image
-        src={imageUrl}
-        alt={title}
-        className="h-48 w-full object-cover"
-        width={200}
-        height={200}
-      />
-      <div className="flex flex-1 flex-col justify-between p-4">
-        <div>
-          <span className="text-sm font-semibold text-blue-600">
-            {category}
-          </span>
-          <h4 className="my-2 text-lg font-semibold">{title}</h4>
-          <p className="mb-4 line-clamp-4 text-sm text-gray-600">
-            {description}
-          </p>
+      {imageUrl ? (
+        <Image
+          src={imageUrl}
+          alt={title}
+          className="h-48 w-full object-cover"
+          width={200}
+          height={200}
+        />
+      ) : (
+        <div className="flex h-48 w-full items-center justify-center bg-gray-200">
+          <span className="text-gray-400">No image available</span>
         </div>
-        <div>
-          <div className="mt-auto flex items-center justify-between">
-            <span className="text-sm text-gray-500">Source: {source}</span>
-            <span className="text-sm text-gray-500">
-              {dayjs(date).format(DateFormats.MMMMDDYYYY)}
-            </span>
-          </div>
-          <Link
-            href={url || ""}
-            target="_blank"
-            className="mt-2 inline-block text-blue-500 hover:underline"
-          >
-            Read More
-          </Link>
-        </div>
+      )}
+      <div className="flex grow flex-col p-6">
+        <ArticleDetails article={article} showFullContent={false} />
       </div>
+      <ReadMoreLink article={article} />
     </article>
   );
 };

--- a/src/components/cards/ArticleDetails.tsx
+++ b/src/components/cards/ArticleDetails.tsx
@@ -1,0 +1,66 @@
+import dayjs from "dayjs";
+
+import { DateFormats } from "@/lib/enums";
+import { Article } from "@/lib/types";
+import { isHTML } from "@/lib/utils";
+import {
+  CalendarIcon,
+  NewspaperIcon,
+  TagIcon,
+  UserIcon,
+} from "@heroicons/react/24/outline";
+
+const ArticleDetails = ({
+  article,
+  showFullContent = false,
+}: {
+  article: Article;
+  showFullContent?: boolean;
+}) => {
+  const renderContent = () => {
+    const content = showFullContent ? article.content : article.description;
+    if (isHTML(content)) {
+      return (
+        <div
+          className={`prose max-w-none ${showFullContent ? "mb-6" : "mb-4 line-clamp-3"}`}
+          dangerouslySetInnerHTML={{ __html: content }}
+        />
+      );
+    } else {
+      return (
+        <p
+          className={`text-gray-800 ${showFullContent ? "mb-6" : "mb-4 line-clamp-3"}`}
+        >
+          {content}
+        </p>
+      );
+    }
+  };
+
+  return (
+    <>
+      <h2 className="mb-4 text-2xl font-bold">{article.title}</h2>
+      <div className="mb-6 flex flex-wrap gap-4">
+        <div className="flex items-center text-sm text-gray-600">
+          <UserIcon className="mr-2 size-5" />
+          <span>{article.author || "Unknown Author"}</span>
+        </div>
+        <div className="flex items-center text-sm text-gray-600">
+          <NewspaperIcon className="mr-2 size-5" />
+          <span>{article.source}</span>
+        </div>
+        <div className="flex items-center text-sm text-gray-600">
+          <CalendarIcon className="mr-2 size-5" />
+          <span>{dayjs(article.date).format(DateFormats.MMMMDDYYYY)}</span>
+        </div>
+        <div className="flex items-center text-sm text-gray-600">
+          <TagIcon className="mr-2 size-5" />
+          <span>{article.category}</span>
+        </div>
+      </div>
+      {renderContent()}
+    </>
+  );
+};
+
+export default ArticleDetails;

--- a/src/components/ui/ArticlesSectionSkeletonUI.tsx
+++ b/src/components/ui/ArticlesSectionSkeletonUI.tsx
@@ -8,18 +8,24 @@ const ArticlesSectionSkeletonUI = () => {
           .map((i) => (
             <article
               key={`article-${i}`}
-              className="overflow-hidden rounded-lg bg-white shadow-md"
+              className="flex animate-pulse flex-col overflow-hidden rounded-lg bg-white shadow-md"
             >
-              <div className="h-48 w-full bg-gray-300"></div>
-              <div className="p-4">
-                <div className="mb-2 h-4 w-1/4 rounded bg-gray-300"></div>
-                <div className="mb-2 h-6 w-3/4 rounded bg-gray-300"></div>
-                <div className="mb-4 h-4 w-full rounded bg-gray-300"></div>
-                <div className="flex items-center justify-between">
-                  <div className="h-4 w-1/4 rounded bg-gray-300"></div>
-                  <div className="h-4 w-1/4 rounded bg-gray-300"></div>
+              <div className="h-48 w-full bg-gray-300" />
+              <div className="flex grow flex-col p-6">
+                <div className="mb-2 h-6 w-3/4 rounded bg-gray-300" />
+                <div className="mb-2 h-4 w-full rounded bg-gray-300" />
+                <div className="mb-2 h-4 w-full rounded bg-gray-300" />
+                <div className="mb-4 h-4 w-2/3 rounded bg-gray-300" />
+                <div className="mt-auto space-y-2">
+                  {[...Array(4)].map((_, index) => (
+                    <div key={index} className="flex items-center">
+                      <div className="mr-2 size-4 rounded-full bg-gray-300" />
+                      <div className="h-4 w-1/2 rounded bg-gray-300" />
+                    </div>
+                  ))}
                 </div>
               </div>
+              <div className="h-10 bg-gray-300" />
             </article>
           ))}
       </div>

--- a/src/components/ui/ReadMoreLink.tsx
+++ b/src/components/ui/ReadMoreLink.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import Link from "next/link";
+
+import { useArticle } from "@/contexts/ArticleContext";
+import { Article } from "@/lib/types";
+
+const ReadMoreLink = ({ article }: { article: Article }) => {
+  const { setSelectedArticle } = useArticle();
+
+  const handleClick = () => {
+    setSelectedArticle(article);
+  };
+
+  return (
+    <Link
+      href="/article"
+      onClick={handleClick}
+      className="block bg-gray-100 py-3 text-center text-blue-500 transition duration-300 hover:bg-gray-200"
+    >
+      Read More
+    </Link>
+  );
+};
+
+export default ReadMoreLink;

--- a/src/contexts/ArticleContext.tsx
+++ b/src/contexts/ArticleContext.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+import { LocalStorageKeys } from "@/lib/enums";
+import { Article } from "@/lib/types";
+
+interface ArticleContextType {
+  selectedArticle: Article | null;
+  // eslint-disable-next-line no-unused-vars
+  setSelectedArticle: (article: Article | null) => void;
+}
+
+const ArticleContext = createContext<ArticleContextType | undefined>(undefined);
+
+export function ArticleProvider({ children }: { children: React.ReactNode }) {
+  const [selectedArticle, setSelectedArticle] = useState<Article | null>(null);
+
+  useEffect(() => {
+    const storedArticle = localStorage.getItem(
+      LocalStorageKeys.selectedArticle
+    );
+    if (storedArticle) {
+      setSelectedArticle(JSON.parse(storedArticle));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (selectedArticle) {
+      localStorage.setItem(
+        LocalStorageKeys.selectedArticle,
+        JSON.stringify(selectedArticle)
+      );
+    } else {
+      localStorage.removeItem(LocalStorageKeys.selectedArticle);
+    }
+  }, [selectedArticle]);
+
+  return (
+    <ArticleContext.Provider value={{ selectedArticle, setSelectedArticle }}>
+      {children}
+    </ArticleContext.Provider>
+  );
+}
+
+export function useArticle() {
+  const context = useContext(ArticleContext);
+  if (context === undefined) {
+    throw new Error("useArticle must be used within an ArticleProvider");
+  }
+  return context;
+}

--- a/src/lib/actions/guardianApi.actions.ts
+++ b/src/lib/actions/guardianApi.actions.ts
@@ -8,7 +8,7 @@ import { getErrorMessage } from "@/lib/utils";
 
 const GuardianAPIResponseFormat = "json";
 const GuardianAPIShowFields =
-  "headline,thumbnail,short-url,trailText,publication";
+  "headline,thumbnail,short-url,trailText,publication,body,byline";
 
 export const getGuardianApiArticles = async ({
   page,
@@ -71,6 +71,8 @@ export const getGuardianApiArticles = async ({
             url: fields.shortUrl,
             date: webPublicationDate,
             category: sectionName,
+            content: fields.body,
+            author: fields.byline,
           })
         ) || [],
       totalPages: response.data.response.pages,

--- a/src/lib/actions/newYorkTimesApi.actions.ts
+++ b/src/lib/actions/newYorkTimesApi.actions.ts
@@ -71,6 +71,8 @@ export const getNewYorkTimesApiArticles = async ({
             multimedia,
             pub_date,
             section_name,
+            snippet,
+            byline,
           }) => ({
             id: randomUUID(),
             title: headline.main,
@@ -80,6 +82,8 @@ export const getNewYorkTimesApiArticles = async ({
             url: web_url,
             date: pub_date,
             category: section_name,
+            content: snippet,
+            author: byline.original,
           })
         ) || [],
       totalPages: Math.ceil(response.data.response.meta.hits / PAGE_SIZE),

--- a/src/lib/actions/newsApi.actions.ts
+++ b/src/lib/actions/newsApi.actions.ts
@@ -58,7 +58,16 @@ export const getNewsApiArticles = async ({
     return {
       data:
         response?.data?.articles.map(
-          ({ title, description, urlToImage, source, url, publishedAt }) => ({
+          ({
+            title,
+            description,
+            urlToImage,
+            source,
+            url,
+            publishedAt,
+            content,
+            author,
+          }) => ({
             id: randomUUID(),
             title,
             description,
@@ -67,6 +76,8 @@ export const getNewsApiArticles = async ({
             url,
             date: publishedAt,
             category: "",
+            content,
+            author,
           })
         ) || [],
       totalPages: response.data.totalResults,

--- a/src/lib/enums.ts
+++ b/src/lib/enums.ts
@@ -37,3 +37,7 @@ export const enum CookiesKeys {
 export const enum DateFormats {
   MMMMDDYYYY = "MMMM DD, YYYY",
 }
+
+export const enum LocalStorageKeys {
+  selectedArticle = "selected-article",
+}

--- a/src/lib/types/guardianApi.d.ts
+++ b/src/lib/types/guardianApi.d.ts
@@ -14,6 +14,8 @@ type GuardianAPIArticle = {
     shortUrl: string;
     thumbnail: string;
     publication: string;
+    body: string;
+    byline: string;
   };
   isHosted: boolean;
   pillarId: string;

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -14,6 +14,8 @@ type Article = {
   url: string;
   date: string;
   category: string;
+  content: string;
+  author: string;
 };
 
 type ArticleAPIResponse =

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -58,3 +58,12 @@ export const getErrorMessage = (error: unknown): string => {
 
   return message;
 };
+
+export function isHTML(str: string): boolean {
+  try {
+    const doc = new DOMParser().parseFromString(str, "text/html");
+    return Array.from(doc.body.childNodes).some((node) => node.nodeType === 1);
+  } catch (error) {
+    return false;
+  }
+}


### PR DESCRIPTION
- Implemented article details page and modal using Next.js parallel and intercepting routes.
- Added functionality to parse author and content from news APIs and display on article details.
- Added 'Read Full Article' button on article details page and modal, which redirects to the news website URL provided in the API response.