### PR TITLE
fix(NewsApiArticle): fix author type in NewsApiArticle

### DIFF
--- a/src/lib/types/newsApi.d.ts
+++ b/src/lib/types/newsApi.d.ts
@@ -2,7 +2,7 @@
 
 type NewsAPIArticle = {
   source: { id: string; name: string };
-  author?: string;
+  author: string;
   title: string;
   description: string;
   url: string;


### PR DESCRIPTION
- Changed the type of the 'author' property in the 'NewsApiArticle' interface from 'string | undefined' to 'string'.
- This ensures that the 'author' property is always a string, preventing potential errors when accessing the author's name.