### PR TITLE
fix(personalized-news-feed-form): fix preferred authors not saving in search params

### DIFF
--- a/src/components/forms/PersonalizedNewsFeedForm.tsx
+++ b/src/components/forms/PersonalizedNewsFeedForm.tsx
@@ -60,7 +60,7 @@ const PersonalizedNewsFeedForm = ({
         params.set("category", preferredCategories.join(","));
       }
 
-      if (preferredCategories?.length > 0) {
+      if (preferredAuthors) {
         params.set("authors", preferredAuthors);
       }
 


### PR DESCRIPTION
- Fixed an issue where the 'preferredAuthors' variable was not being correctly saved to the searchParams string in the PersonalizedNewsFeedForm component.