### PR TITLE
refactor(routing): define routes and search params in enums

### DIFF
--- a/src/app/article/page.tsx
+++ b/src/app/article/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 
 import ArticleDetails from "@/components/articles/ArticleDetails";
 import useArticle from "@/hooks/useArticle";
+import { Paths } from "@/types/enums";
 
 export default function ArticlePage() {
   const { selectedArticle } = useArticle();
@@ -14,7 +15,7 @@ export default function ArticlePage() {
 
   useEffect(() => {
     if (!selectedArticle) {
-      router.push("/");
+      router.push(Paths.home);
     }
   }, [selectedArticle, router]);
 
@@ -24,7 +25,7 @@ export default function ArticlePage() {
     <div className="mx-auto max-w-4xl p-6">
       <ArticleDetails article={selectedArticle} showFullContent={true} />
       <div className="mt-6 flex items-center justify-between">
-        <Link href="/" className="text-blue-500 hover:underline">
+        <Link href={Paths.home} className="text-blue-500 hover:underline">
           ← Back to Home
         </Link>
         <a

--- a/src/components/forms/PersonalizedNewsFeedForm.tsx
+++ b/src/components/forms/PersonalizedNewsFeedForm.tsx
@@ -9,7 +9,10 @@ import Input from "@/components/ui/Input";
 import { CATEGORIES_OPTIONS, NEWS_SOURCES_OPTIONS } from "@/config/constants";
 import { PersonalizedNewsFeedFormSchema } from "@/lib/schemas";
 import { setPersonalizedFeedPrefrences } from "@/services/feedService";
-import { PersonalizedNewsFeedFormFields } from "@/types/enums";
+import {
+  PageSearchParams,
+  PersonalizedNewsFeedFormFields,
+} from "@/types/enums";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 const PersonalizedNewsFeedForm = ({
@@ -20,9 +23,9 @@ const PersonalizedNewsFeedForm = ({
   const getFormDefaultValues = useCallback(() => {
     const params = new URLSearchParams(personalizedNewsFeedPreferences || "");
 
-    const preferredNewsSources = params.get("newsSource");
-    const preferredCategories = params.get("category");
-    const preferredAuthors = params.get("authors");
+    const preferredNewsSources = params.get(PageSearchParams.newsSource);
+    const preferredCategories = params.get(PageSearchParams.category);
+    const preferredAuthors = params.get(PageSearchParams.authors);
 
     return {
       [PersonalizedNewsFeedFormFields.preferredNewsSources]:
@@ -53,15 +56,15 @@ const PersonalizedNewsFeedForm = ({
         formData[PersonalizedNewsFeedFormFields.preferredAuthors];
 
       if (preferredNewsSources?.length > 0) {
-        params.set("newsSource", preferredNewsSources.join(","));
+        params.set(PageSearchParams.newsSource, preferredNewsSources.join(","));
       }
 
       if (preferredCategories?.length > 0) {
-        params.set("category", preferredCategories.join(","));
+        params.set(PageSearchParams.category, preferredCategories.join(","));
       }
 
       if (preferredAuthors) {
-        params.set("authors", preferredAuthors);
+        params.set(PageSearchParams.authors, preferredAuthors);
       }
 
       setPersonalizedFeedPrefrences(params.toString());

--- a/src/components/forms/SearchArticlesForm.tsx
+++ b/src/components/forms/SearchArticlesForm.tsx
@@ -7,9 +7,9 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import Button from "@/components/ui/Button";
 import Dropdown from "@/components/ui/Dropdown";
 import Input from "@/components/ui/Input";
-import { CATEGORIES, NEWS_SOURCES } from "@/config/constants";
+import { CATEGORIES, DEFAULT_PAGE, NEWS_SOURCES } from "@/config/constants";
 import { SearchArticlesFormSchema } from "@/lib/schemas";
-import { SearchArticlesFormFields } from "@/types/enums";
+import { PageSearchParams, SearchArticlesFormFields } from "@/types/enums";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 const SearchArticlesForm = () => {
@@ -20,12 +20,16 @@ const SearchArticlesForm = () => {
   const searchArticlesForm = useForm({
     resolver: zodResolver(SearchArticlesFormSchema),
     defaultValues: {
-      [SearchArticlesFormFields.keyword]: searchParams.get("keyword") || "",
-      [SearchArticlesFormFields.fromDate]: searchParams.get("fromDate") || "",
-      [SearchArticlesFormFields.toDate]: searchParams.get("toDate") || "",
+      [SearchArticlesFormFields.keyword]:
+        searchParams.get(PageSearchParams.keyword) || "",
+      [SearchArticlesFormFields.fromDate]:
+        searchParams.get(PageSearchParams.fromDate) || "",
+      [SearchArticlesFormFields.toDate]:
+        searchParams.get(PageSearchParams.toDate) || "",
       [SearchArticlesFormFields.newsSource]:
-        searchParams.get("newsSource") || "",
-      [SearchArticlesFormFields.category]: searchParams.get("category") || "",
+        searchParams.get(PageSearchParams.newsSource) || "",
+      [SearchArticlesFormFields.category]:
+        searchParams.get(PageSearchParams.category) || "",
     },
   });
 
@@ -41,26 +45,26 @@ const SearchArticlesForm = () => {
     const category = formData[SearchArticlesFormFields.category];
 
     if (keyword) {
-      params.set("keyword", keyword);
-    } else params.delete("keyword");
+      params.set(PageSearchParams.keyword, keyword);
+    } else params.delete(PageSearchParams.keyword);
 
     if (fromDate) {
-      params.set("fromDate", fromDate);
-    } else params.delete("fromDate");
+      params.set(PageSearchParams.fromDate, fromDate);
+    } else params.delete(PageSearchParams.fromDate);
 
     if (toDate) {
-      params.set("toDate", toDate);
-    } else params.delete("toDate");
+      params.set(PageSearchParams.toDate, toDate);
+    } else params.delete(PageSearchParams.toDate);
 
     if (newsSource) {
-      params.set("newsSource", newsSource);
-    } else params.delete("newsSource");
+      params.set(PageSearchParams.newsSource, newsSource);
+    } else params.delete(PageSearchParams.newsSource);
 
     if (category) {
-      params.set("category", category);
-    } else params.delete("category");
+      params.set(PageSearchParams.category, category);
+    } else params.delete(PageSearchParams.category);
 
-    params.set("page", "1");
+    params.set(PageSearchParams.page, `${DEFAULT_PAGE}`);
 
     replace(`${pathname}?${params.toString()}`);
   });

--- a/src/components/forms/SearchPersonalizedNewsFeedForm.tsx
+++ b/src/components/forms/SearchPersonalizedNewsFeedForm.tsx
@@ -4,6 +4,9 @@ import { useEffect } from "react";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
+import { DEFAULT_PAGE } from "@/config/constants";
+import { PageSearchParams, Paths } from "@/types/enums";
+
 const SearchPersonalizedNewsFeedForm = ({
   personalizedNewsFeedPreferences,
 }: {
@@ -16,18 +19,18 @@ const SearchPersonalizedNewsFeedForm = ({
   useEffect(() => {
     if (personalizedNewsFeedPreferences) {
       if (
-        !searchParams.has("newsSource") &&
-        !searchParams.has("category") &&
-        !searchParams.has("authors")
+        !searchParams.has(PageSearchParams.newsSource) &&
+        !searchParams.has(PageSearchParams.category) &&
+        !searchParams.has(PageSearchParams.authors)
       ) {
         const params = new URLSearchParams(personalizedNewsFeedPreferences);
 
-        params.set("page", "1");
+        params.set(PageSearchParams.page, `${DEFAULT_PAGE}`);
 
         replace(`${pathname}?${params.toString()}`);
       }
     } else {
-      replace("/settings");
+      replace(Paths.settings);
     }
   }, [pathname, personalizedNewsFeedPreferences, replace, searchParams]);
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { Paths } from "@/types/enums";
+
 const Footer = () => {
   return (
     <footer className="bg-gray-800 py-8 text-white">
@@ -14,22 +16,22 @@ const Footer = () => {
           <nav>
             <ul className="flex flex-wrap justify-center space-x-4 md:justify-end">
               <li>
-                <Link href="/" className="hover:text-gray-300">
+                <Link href={Paths.home} className="hover:text-gray-300">
                   About
                 </Link>
               </li>
               <li>
-                <Link href="/" className="hover:text-gray-300">
+                <Link href={Paths.home} className="hover:text-gray-300">
                   Contact
                 </Link>
               </li>
               <li>
-                <Link href="/" className="hover:text-gray-300">
+                <Link href={Paths.home} className="hover:text-gray-300">
                   Privacy Policy
                 </Link>
               </li>
               <li>
-                <Link href="/" className="hover:text-gray-300">
+                <Link href={Paths.home} className="hover:text-gray-300">
                   Terms of Service
                 </Link>
               </li>

--- a/src/components/ui/Pagination.tsx
+++ b/src/components/ui/Pagination.tsx
@@ -4,16 +4,17 @@ import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 
 import { generatePaginationArray } from "@/lib/utils";
+import { PageSearchParams } from "@/types/enums";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
 
 const Pagination = ({ totalPages }: { totalPages: number }) => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const currentPage = Number(searchParams.get("page")) || 1;
+  const currentPage = Number(searchParams.get(PageSearchParams.page)) || 1;
 
   const createPageURL = (pageNumber: number | string) => {
     const params = new URLSearchParams(searchParams);
-    params.set("page", pageNumber.toString());
+    params.set(PageSearchParams.page, pageNumber.toString());
     return `${pathname}?${params.toString()}`;
   };
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,4 +1,4 @@
-import { Categories, NewsSources } from "@/types/enums";
+import { Categories, NewsSources, Paths } from "@/types/enums";
 
 export const PAGE_SIZE = 10;
 
@@ -8,15 +8,15 @@ export const CONTENT_TYPE_APPLICATION_JSON = "application/json";
 
 export const ROUTES = [
   {
-    path: "/",
+    path: Paths.home,
     label: "Home",
   },
   {
-    path: "/feed",
+    path: Paths.feed,
     label: "My Feed",
   },
   {
-    path: "/settings",
+    path: Paths.settings,
     label: "Settings",
   },
 ];

--- a/src/services/feedService.ts
+++ b/src/services/feedService.ts
@@ -7,7 +7,7 @@ import { shuffleArray } from "@/lib/utils";
 import { getGuardianApiArticles } from "@/services/guardianApiService";
 import { getNewYorkTimesApiArticles } from "@/services/newYorkTimesApiService";
 import { getNewsApiArticles } from "@/services/newsApiService";
-import { CookiesKeys, NewsSources } from "@/types/enums";
+import { CookiesKeys, NewsSources, Paths } from "@/types/enums";
 
 export const setPersonalizedFeedPrefrences = async (
   personalizedNewsFeed: string
@@ -15,9 +15,9 @@ export const setPersonalizedFeedPrefrences = async (
   cookies().set(
     CookiesKeys.personalizedNewsFeedPreferences,
     personalizedNewsFeed,
-    { httpOnly: true, path: "/" }
+    { httpOnly: true, path: Paths.home }
   );
-  redirect("/feed");
+  redirect(Paths.feed);
 };
 
 const getGuardianArticlesForCategories = async ({

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -41,3 +41,19 @@ export const enum DateFormats {
 export const enum LocalStorageKeys {
   selectedArticle = "selected-article",
 }
+
+export const enum PageSearchParams {
+  keyword = "keyword",
+  fromDate = "fromDate",
+  toDate = "toDate",
+  newsSource = "newsSource",
+  category = "category",
+  authors = "authors",
+  page = "page",
+}
+
+export const enum Paths {
+  home = "/",
+  feed = "/feed",
+  settings = "/settings",
+}


### PR DESCRIPTION
- Refactored routing logic to use enums for defining routes and search parameters.
- This improves code readability and maintainability by centralizing route definitions.