### PR TITLE
feat(articles-preferences): show loader and disable button on form submit

### DIFF
--- a/src/components/forms/PersonalizedNewsFeedForm.tsx
+++ b/src/components/forms/PersonalizedNewsFeedForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useTransition } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
 import Button from "@/components/ui/Button";
@@ -20,6 +20,8 @@ const PersonalizedNewsFeedForm = ({
 }: {
   personalizedNewsFeedPreferences?: string;
 }) => {
+  const [isPending, startTransition] = useTransition();
+
   const getFormDefaultValues = useCallback(() => {
     const params = new URLSearchParams(personalizedNewsFeedPreferences || "");
 
@@ -46,28 +48,33 @@ const PersonalizedNewsFeedForm = ({
 
   const onSubmit = handleSubmit(
     (formData) => {
-      const params = new URLSearchParams("");
+      startTransition(() => {
+        const params = new URLSearchParams("");
 
-      const preferredNewsSources =
-        formData[PersonalizedNewsFeedFormFields.preferredNewsSources];
-      const preferredCategories =
-        formData[PersonalizedNewsFeedFormFields.preferredCategories];
-      const preferredAuthors =
-        formData[PersonalizedNewsFeedFormFields.preferredAuthors];
+        const preferredNewsSources =
+          formData[PersonalizedNewsFeedFormFields.preferredNewsSources];
+        const preferredCategories =
+          formData[PersonalizedNewsFeedFormFields.preferredCategories];
+        const preferredAuthors =
+          formData[PersonalizedNewsFeedFormFields.preferredAuthors];
 
-      if (preferredNewsSources?.length > 0) {
-        params.set(PageSearchParams.newsSource, preferredNewsSources.join(","));
-      }
+        if (preferredNewsSources?.length > 0) {
+          params.set(
+            PageSearchParams.newsSource,
+            preferredNewsSources.join(",")
+          );
+        }
 
-      if (preferredCategories?.length > 0) {
-        params.set(PageSearchParams.category, preferredCategories.join(","));
-      }
+        if (preferredCategories?.length > 0) {
+          params.set(PageSearchParams.category, preferredCategories.join(","));
+        }
 
-      if (preferredAuthors) {
-        params.set(PageSearchParams.authors, preferredAuthors);
-      }
+        if (preferredAuthors) {
+          params.set(PageSearchParams.authors, preferredAuthors);
+        }
 
-      setPersonalizedFeedPrefrences(params.toString());
+        setPersonalizedFeedPrefrences(params.toString());
+      });
     },
     (error) => console.error(error)
   );
@@ -120,7 +127,9 @@ const PersonalizedNewsFeedForm = ({
           </div>
         </div>
 
-        <Button type="submit">Save Preferences</Button>
+        <Button type="submit" loading={isPending}>
+          Save Preferences
+        </Button>
       </form>
     </FormProvider>
   );

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,16 +1,33 @@
 import { ButtonHTMLAttributes, PropsWithChildren } from "react";
 
+import { ArrowPathIcon } from "@heroicons/react/24/solid";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  loading?: boolean;
+}
+
 const Button = ({
   children,
   className,
+  loading = false,
+  disabled,
   ...props
-}: PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>>) => {
+}: PropsWithChildren<ButtonProps>) => {
   return (
     <button
       {...props}
-      className={`w-full rounded-md bg-blue-500 px-4 py-2 font-medium text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 md:w-auto ${className}`}
+      disabled={disabled || loading}
+      className={`relative w-full rounded-md bg-blue-500 px-4 py-2 font-medium text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:w-auto ${className}`}
     >
-      {children}
+      {loading && (
+        <span className="absolute inset-0 flex items-center justify-center">
+          <ArrowPathIcon
+            className="size-5 animate-spin text-white"
+            aria-hidden="true"
+          />
+        </span>
+      )}
+      <span className={loading ? "invisible" : "visible"}>{children}</span>
     </button>
   );
 };

--- a/src/services/feedService.ts
+++ b/src/services/feedService.ts
@@ -9,9 +9,7 @@ import { getNewYorkTimesApiArticles } from "@/services/newYorkTimesApiService";
 import { getNewsApiArticles } from "@/services/newsApiService";
 import { CookiesKeys, NewsSources, Paths } from "@/types/enums";
 
-export const setPersonalizedFeedPrefrences = async (
-  personalizedNewsFeed: string
-) => {
+export const setPersonalizedFeedPrefrences = (personalizedNewsFeed: string) => {
   cookies().set(
     CookiesKeys.personalizedNewsFeedPreferences,
     personalizedNewsFeed,


### PR DESCRIPTION
- Added a loader to the 'Set Articles Preferences' form.
- Disabled the submit button when the form is submitted.