### PR TITLE
fix(dialog): fix dialog scrollability and height

### DIFF
--- a/src/app/@modal/(.)article/loading.tsx
+++ b/src/app/@modal/(.)article/loading.tsx
@@ -2,10 +2,7 @@ import ArticleDetailsSkeletonUI from "@/components/ui/ArticleDetailsSkeletonUI";
 
 export default function ArticleModalLoader() {
   return (
-    <dialog
-      open
-      className="fixed inset-0 z-50 m-0 max-h-full max-w-full overflow-hidden p-0"
-    >
+    <dialog open>
       <div
         className="fixed inset-0 bg-black/75 backdrop-blur-sm"
         aria-hidden="true"

--- a/src/app/@modal/(.)article/page.tsx
+++ b/src/app/@modal/(.)article/page.tsx
@@ -28,12 +28,9 @@ export default function ArticleModal() {
   if (!selectedArticle) return null;
 
   return (
-    <dialog
-      ref={dialogRef}
-      className="fixed inset-0 z-50 m-0 max-h-full max-w-full overflow-hidden p-0"
-    >
-      <div className="fixed inset-0 flex items-center justify-center p-4">
-        <div className="relative z-10 max-h-[90vh] w-full max-w-4xl overflow-y-auto rounded-lg bg-white p-6 shadow-xl">
+    <dialog ref={dialogRef}>
+      <div className="fixed inset-0 flex overflow-y-auto p-4">
+        <div className="relative z-10 m-auto w-full max-w-4xl rounded-lg bg-white p-6 shadow-xl">
           <div className="mb-4 flex items-start justify-between">
             <span />
             <button

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,7 +61,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="bg-gray-100">
+      <body className="bg-gray-100 [&:has(dialog[open])]:overflow-hidden">
         <ArticleProvider>
           <Header />
           {children}


### PR DESCRIPTION
- Fixed an issue where the body remained scrollable when a dialog was open.
- Implemented a fix to prevent body scrolling and set dialog height to 'auto' when a dialog is open.
- Added scrolling within the dialog content area to allow for content larger than the dialog height.