### PR TITLE
fix(article-page): fix redirect to / on article page

### DIFF
--- a/src/app/article/page.tsx
+++ b/src/app/article/page.tsx
@@ -14,7 +14,7 @@ export default function ArticlePage() {
   const router = useRouter();
 
   useEffect(() => {
-    if (!selectedArticle) {
+    if (selectedArticle === null) {
       router.push(Paths.home);
     }
   }, [selectedArticle, router]);

--- a/src/contexts/ArticleContext.tsx
+++ b/src/contexts/ArticleContext.tsx
@@ -5,7 +5,7 @@ import { createContext, useEffect, useState } from "react";
 import { LocalStorageKeys } from "@/types/enums";
 
 interface ArticleContextType {
-  selectedArticle: Article | null;
+  selectedArticle?: Article | null;
   // eslint-disable-next-line no-unused-vars
   setSelectedArticle: (article: Article | null) => void;
 }
@@ -15,15 +15,13 @@ export const ArticleContext = createContext<ArticleContextType | undefined>(
 );
 
 export function ArticleProvider({ children }: { children: React.ReactNode }) {
-  const [selectedArticle, setSelectedArticle] = useState<Article | null>(null);
+  const [selectedArticle, setSelectedArticle] = useState<Article | null>();
 
   useEffect(() => {
     const storedArticle = localStorage.getItem(
       LocalStorageKeys.selectedArticle
     );
-    if (storedArticle) {
-      setSelectedArticle(JSON.parse(storedArticle));
-    }
+    setSelectedArticle(storedArticle ? JSON.parse(storedArticle) : null);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
- Resolved an issue where the /article page was redirecting to / due to an initial 'null' value for 'selectedArticle'.
- Set the default value of 'selectedArticle' to 'undefined'.
- Added a check within 'useEffect' to redirect to / only if 'selectedArticle' is 'null', and the value is retrieved from localStorage.