### PR TITLE
fix(ui): update article button text and manifest file path

### DIFF
--- a/public/assets/browserconfig.xml
+++ b/public/assets/browserconfig.xml
@@ -2,7 +2,7 @@
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="/mstile-150x150.png"/>
+            <square150x150logo src="/assets/mstile-150x150.png"/>
             <TileColor>#da532c</TileColor>
         </tile>
     </msapplication>

--- a/public/assets/site.webmanifest
+++ b/public/assets/site.webmanifest
@@ -1,14 +1,14 @@
 {
-  "name": "",
-  "short_name": "",
+  "name": "News Aggregator",
+  "short_name": "News Aggregator",
   "icons": [
     {
-      "src": "/android-chrome-192x192.png",
+      "src": "/assets/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/android-chrome-512x512.png",
+      "src": "/assets/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/src/components/ui/ReadMoreLink.tsx
+++ b/src/components/ui/ReadMoreLink.tsx
@@ -18,7 +18,7 @@ const ReadMoreLink = ({ article }: { article: Article }) => {
       aria-label={article.title}
       className="block bg-gray-100 py-3 text-center text-blue-500 transition duration-300 hover:bg-gray-200"
     >
-      Read More
+      Read Full Article
     </Link>
   );
 };


### PR DESCRIPTION
- Changed 'Read More' button text to 'Read Full Article'.
- Corrected the file path for 'android-chrome-192x192.png' in the site.webmanifest file.