### PR TITLE
refactor(api-clients): migrate axios api clients to fetch

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  experimental: {
+    ppr: true,
+    dynamicIO: true,
+  },
   images: {
     unoptimized: true,
     remotePatterns: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,10 @@
       "dependencies": {
         "@heroicons/react": "^2.1.5",
         "@hookform/resolvers": "^3.9.0",
-        "axios": "^1.7.7",
         "dayjs": "^1.11.13",
-        "next": "15.0.2",
-        "react": "19.0.0-rc-02c0e824-20241028",
-        "react-dom": "19.0.0-rc-02c0e824-20241028",
+        "next": "15.0.3-canary.3",
+        "react": "19.0.0-rc-603e6108-20241029",
+        "react-dom": "19.0.0-rc-603e6108-20241029",
         "react-hook-form": "^7.53.0",
         "zod": "^3.23.8"
       },
@@ -25,7 +24,7 @@
         "@types/react-dom": "npm:types-react-dom@19.0.0-rc.1",
         "encyrpt-decrypt-env": "^1.0.10",
         "eslint": "^8.57.1",
-        "eslint-config-next": "15.0.2",
+        "eslint-config-next": "15.0.3-canary.3",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-tailwindcss": "^3.17.4",
@@ -966,14 +965,14 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.0.2.tgz",
-      "integrity": "sha512-c0Zr0ModK5OX7D4ZV8Jt/wqoXtitLNPwUfG9zElCZztdaZyNVnN40rDXVZ/+FGuR4CcNV5AEfM6N8f+Ener7Dg=="
+      "version": "15.0.3-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.0.3-canary.3.tgz",
+      "integrity": "sha512-qAKngFCCGpsz4GD4MohU+HLQ6EMbUL0gFPvmPWD2PYbOLjjl/O3/kbH1iD5eb+qUVm/W9grR33Fy3SGcBRcKmg=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.0.2.tgz",
-      "integrity": "sha512-R9Jc7T6Ge0txjmqpPwqD8vx6onQjynO9JT73ArCYiYPvSrwYXepH/UY/WdKDY8JPWJl72sAE4iGMHPeQ5xdEWg==",
+      "version": "15.0.3-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.0.3-canary.3.tgz",
+      "integrity": "sha512-VcnawlCWJ9JB74cEx/6VmUUTu3Wo/CGedGl8Pmh4pbnFi1DmmjLR0fqK/yONKppUz6HJ5hEX7voT9mIyHf3teA==",
       "dev": true,
       "dependencies": {
         "fast-glob": "3.3.1"
@@ -1008,9 +1007,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.0.2.tgz",
-      "integrity": "sha512-GK+8w88z+AFlmt+ondytZo2xpwlfAR8U6CRwXancHImh6EdGfHMIrTSCcx5sOSBei00GyLVL0ioo1JLKTfprgg==",
+      "version": "15.0.3-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.0.3-canary.3.tgz",
+      "integrity": "sha512-Sd18pHtxCzuxIi4WgFjEJaGwBSEMJShmMVNPG9IxFozGLgU2zXj+7OvpjlN8hylaG6TviC8rKdlZzggq4SsmXg==",
       "cpu": [
         "arm64"
       ],
@@ -1023,9 +1022,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.0.2.tgz",
-      "integrity": "sha512-KUpBVxIbjzFiUZhiLIpJiBoelqzQtVZbdNNsehhUn36e2YzKHphnK8eTUW1s/4aPy5kH/UTid8IuVbaOpedhpw==",
+      "version": "15.0.3-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.0.3-canary.3.tgz",
+      "integrity": "sha512-mCTAQzHjRj23JOXhbRyb/bmg6j9ddSkwA+anbN8oUOvkd7FV77c6DLSYhA2ksgKQBTpr7wHiIJ0+lCyAOpOXHw==",
       "cpu": [
         "x64"
       ],
@@ -1038,9 +1037,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.0.2.tgz",
-      "integrity": "sha512-9J7TPEcHNAZvwxXRzOtiUvwtTD+fmuY0l7RErf8Yyc7kMpE47MIQakl+3jecmkhOoIyi/Rp+ddq7j4wG6JDskQ==",
+      "version": "15.0.3-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.0.3-canary.3.tgz",
+      "integrity": "sha512-2Ji/V4cS81ourULgHAvkQosTK64yZJaW4VtCOEGoOPdbFayi+ZUvZ2uiitmoXLStueO75EIrX2KCeAamOI7kfQ==",
       "cpu": [
         "arm64"
       ],
@@ -1053,9 +1052,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.0.2.tgz",
-      "integrity": "sha512-BjH4ZSzJIoTTZRh6rG+a/Ry4SW0HlizcPorqNBixBWc3wtQtj4Sn9FnRZe22QqrPnzoaW0ctvSz4FaH4eGKMww==",
+      "version": "15.0.3-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.0.3-canary.3.tgz",
+      "integrity": "sha512-47SKixzH2Zr8WSfEwG+leUo5Qo9H9fNG8qRBWSsSBJnuX/OqMuq6A4qWxldDTmToMJwb0N8OZiiO1Y2IFngrag==",
       "cpu": [
         "arm64"
       ],
@@ -1068,9 +1067,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.0.2.tgz",
-      "integrity": "sha512-i3U2TcHgo26sIhcwX/Rshz6avM6nizrZPvrDVDY1bXcLH1ndjbO8zuC7RoHp0NSK7wjJMPYzm7NYL1ksSKFreA==",
+      "version": "15.0.3-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.0.3-canary.3.tgz",
+      "integrity": "sha512-HGwwemVZVH1NFw9pIo9jy4ja882W2yxFOIiSzMXDnGjD3osB9blDBYxRT9uxOo/JYqbnR45+usHL9zbQmnD67w==",
       "cpu": [
         "x64"
       ],
@@ -1083,9 +1082,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.0.2.tgz",
-      "integrity": "sha512-AMfZfSVOIR8fa+TXlAooByEF4OB00wqnms1sJ1v+iu8ivwvtPvnkwdzzFMpsK5jA2S9oNeeQ04egIWVb4QWmtQ==",
+      "version": "15.0.3-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.0.3-canary.3.tgz",
+      "integrity": "sha512-Weva4YOb5q+knkinC/Ehwy1jDMiVYyBpkuhrQxlZ2Hy323Asf0VU604r0Uos7qR1Ttw4u293E5HkEf8m7nkPNw==",
       "cpu": [
         "x64"
       ],
@@ -1098,9 +1097,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.0.2.tgz",
-      "integrity": "sha512-JkXysDT0/hEY47O+Hvs8PbZAeiCQVxKfGtr4GUpNAhlG2E0Mkjibuo8ryGD29Qb5a3IOnKYNoZlh/MyKd2Nbww==",
+      "version": "15.0.3-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.0.3-canary.3.tgz",
+      "integrity": "sha512-Z7looUlyWMbtoJKtdMWj/bnns+jyQiwvqxwRegtmBVp2dHSFAnKC0wNBj9z01qu4bB3gEzEBBcVhAVrXAUHYbA==",
       "cpu": [
         "arm64"
       ],
@@ -1113,9 +1112,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.0.2.tgz",
-      "integrity": "sha512-foaUL0NqJY/dX0Pi/UcZm5zsmSk5MtP/gxx3xOPyREkMFN+CTjctPfu3QaqrQHinaKdPnMWPJDKt4VjDfTBe/Q==",
+      "version": "15.0.3-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.0.3-canary.3.tgz",
+      "integrity": "sha512-IJzVKc/bQdP+GYKdHob7kcYVJBsde8W1lwDjKxCcZ9U68vWW0pE5l/4ot/26Dg0+Qpjj+iBVUuY9nSKQ32pgXQ==",
       "cpu": [
         "x64"
       ],
@@ -1997,11 +1996,6 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2024,16 +2018,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2388,17 +2372,6 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2595,14 +2568,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-libc": {
@@ -2970,12 +2935,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.0.2.tgz",
-      "integrity": "sha512-N8o6cyUXzlMmQbdc2Kc83g1qomFi3ITqrAZfubipVKET2uR2mCStyGRcx/r8WiAIVMul2KfwRiCHBkTpBvGBmA==",
+      "version": "15.0.3-canary.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.0.3-canary.3.tgz",
+      "integrity": "sha512-URYtrknXdSXP+nANAlh7pJ5s1AEPZum/K0MZDdWZdChpXrt6/U6iGii+L+lkLcZgttg24z1syiSwHPyR8SewfA==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "15.0.2",
+        "@next/eslint-plugin-next": "15.0.3-canary.3",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -3547,25 +3512,6 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -3589,19 +3535,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -5048,25 +4981,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -5162,11 +5076,11 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.0.2.tgz",
-      "integrity": "sha512-rxIWHcAu4gGSDmwsELXacqAPUk+j8dV/A9cDF5fsiCMpkBDYkO2AEaL1dfD+nNmDiU6QMCFN8Q30VEKapT9UHQ==",
+      "version": "15.0.3-canary.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.0.3-canary.3.tgz",
+      "integrity": "sha512-1YA01lqayrTQV5gSaj5LEIijnu9eRfr3zXZ3Qn7n1AMB/wPyrBNukf2lnsi65rSWvqTp4vQoFwdcixihPDV84g==",
       "dependencies": {
-        "@next/env": "15.0.2",
+        "@next/env": "15.0.3-canary.3",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.13",
         "busboy": "1.6.0",
@@ -5178,25 +5092,25 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.0.2",
-        "@next/swc-darwin-x64": "15.0.2",
-        "@next/swc-linux-arm64-gnu": "15.0.2",
-        "@next/swc-linux-arm64-musl": "15.0.2",
-        "@next/swc-linux-x64-gnu": "15.0.2",
-        "@next/swc-linux-x64-musl": "15.0.2",
-        "@next/swc-win32-arm64-msvc": "15.0.2",
-        "@next/swc-win32-x64-msvc": "15.0.2",
+        "@next/swc-darwin-arm64": "15.0.3-canary.3",
+        "@next/swc-darwin-x64": "15.0.3-canary.3",
+        "@next/swc-linux-arm64-gnu": "15.0.3-canary.3",
+        "@next/swc-linux-arm64-musl": "15.0.3-canary.3",
+        "@next/swc-linux-x64-gnu": "15.0.3-canary.3",
+        "@next/swc-linux-x64-musl": "15.0.3-canary.3",
+        "@next/swc-win32-arm64-msvc": "15.0.3-canary.3",
+        "@next/swc-win32-x64-msvc": "15.0.3-canary.3",
         "sharp": "^0.33.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
         "@playwright/test": "^1.41.2",
         "babel-plugin-react-compiler": "*",
-        "react": "^18.2.0 || 19.0.0-rc-02c0e824-20241028",
-        "react-dom": "^18.2.0 || 19.0.0-rc-02c0e824-20241028",
+        "react": "^18.2.0 || 19.0.0-rc-603e6108-20241029",
+        "react-dom": "^18.2.0 || 19.0.0-rc-603e6108-20241029",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
@@ -6027,11 +5941,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6062,22 +5971,22 @@
       ]
     },
     "node_modules/react": {
-      "version": "19.0.0-rc-02c0e824-20241028",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0-rc-02c0e824-20241028.tgz",
-      "integrity": "sha512-GbZ7hpPHQMiEu53BqEaPQVM/4GG4hARo+mqEEnx4rYporDvNvUjutiAFxYFSbu6sgHwcr7LeFv8htEOwALVA2A==",
+      "version": "19.0.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-NXn7GRnAqiL12ZxUJCUjKT5T7jtqHzYp/4moEYZ4Uv0mUhBT4kFbuYQcPSAJTuP67kENUw79DgWfGbqg5qnh1w==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.0.0-rc-02c0e824-20241028",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0-rc-02c0e824-20241028.tgz",
-      "integrity": "sha512-LrZf3DfHL6Fs07wwlUCHrzFTCMM19yA99MvJpfLokN4I2nBAZvREGZjZAn8VPiSfN72+i9j1eL4wB8gC695F3Q==",
+      "version": "19.0.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-1jaWZcv3V6R39ZnDU3FtGSXtEm/z/lCRFnWmvbp019wPffFGKoXDv+i5KoyQ5yUBpwumImFrKTWXYQluOnm7Jw==",
       "dependencies": {
-        "scheduler": "0.25.0-rc-02c0e824-20241028"
+        "scheduler": "0.25.0-rc-603e6108-20241029"
       },
       "peerDependencies": {
-        "react": "19.0.0-rc-02c0e824-20241028"
+        "react": "19.0.0-rc-603e6108-20241029"
       }
     },
     "node_modules/react-hook-form": {
@@ -6383,9 +6292,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.25.0-rc-02c0e824-20241028",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-02c0e824-20241028.tgz",
-      "integrity": "sha512-GysnKjmMSaWcwsKTLzeJO0IhU3EyIiC0ivJKE6yDNLqt3IMxDByx8b6lSNXRNdN+ULUY0WLLjSPaZ0LuU/GnTg=="
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA=="
     },
     "node_modules/semver": {
       "version": "7.6.3",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,10 @@
   "dependencies": {
     "@heroicons/react": "^2.1.5",
     "@hookform/resolvers": "^3.9.0",
-    "axios": "^1.7.7",
     "dayjs": "^1.11.13",
-    "next": "15.0.2",
-    "react": "19.0.0-rc-02c0e824-20241028",
-    "react-dom": "19.0.0-rc-02c0e824-20241028",
+    "next": "15.0.3-canary.3",
+    "react": "19.0.0-rc-603e6108-20241029",
+    "react-dom": "19.0.0-rc-603e6108-20241029",
     "react-hook-form": "^7.53.0",
     "zod": "^3.23.8"
   },
@@ -30,7 +29,7 @@
     "@types/react-dom": "npm:types-react-dom@19.0.0-rc.1",
     "encyrpt-decrypt-env": "^1.0.10",
     "eslint": "^8.57.1",
-    "eslint-config-next": "15.0.2",
+    "eslint-config-next": "15.0.3-canary.3",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-tailwindcss": "^3.17.4",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,8 +6,6 @@ import { ArticleProvider } from "@/contexts/ArticleContext";
 
 import "./globals.css";
 
-export const experimental_ppr = true;
-
 export const metadata: Metadata = {
   title: {
     default: "News Aggregator",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,8 +6,6 @@ import SearchArticlesForm from "@/components/forms/SearchArticlesForm";
 import ArticlesSection from "@/components/sections/ArticlesSection";
 import ArticlesSectionSkeletonUI from "@/components/ui/ArticlesSectionSkeletonUI";
 
-export const experimental_ppr = true;
-
 export const metadata: Metadata = {
   title: "Home",
 };

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -5,9 +5,9 @@ import {
   Paths,
 } from "@/types/enums";
 
-export const PAGE_SIZE = 10;
+export const PAGE_SIZE = "10";
 
-export const DEFAULT_PAGE = 1;
+export const DEFAULT_PAGE = "1";
 
 export const CONTENT_TYPE_APPLICATION_JSON = "application/json";
 

--- a/src/lib/api-clients/guardianApiClient.ts
+++ b/src/lib/api-clients/guardianApiClient.ts
@@ -1,49 +1,64 @@
-import axios from "axios";
-
 import { CONTENT_TYPE_APPLICATION_JSON } from "@/config/constants";
+import { combineURLs, createSearchParams } from "@/lib/utils";
 import { ApiError } from "@/types/errors";
 
-const GUARDIAN_API_KEY = process.env.GUARDIAN_API_KEY;
-const GUARDIAN_API_BASE_URL = process.env.GUARDIAN_API_BASE_URL;
+const GUARDIAN_API_KEY = process.env.GUARDIAN_API_KEY || "";
+const GUARDIAN_API_BASE_URL = process.env.GUARDIAN_API_BASE_URL || "";
 
-const guardianApiClient = axios.create({
-  baseURL: GUARDIAN_API_BASE_URL,
-  headers: {
+async function guardianApiFetch(
+  endpoint: string,
+  options: RequestOptions = {}
+): Promise<Response> {
+  const { params = {}, ...fetchOptions } = options;
+
+  const allParams = { ...params, "api-key": GUARDIAN_API_KEY };
+
+  const fullURL = combineURLs(GUARDIAN_API_BASE_URL, endpoint);
+  const url = new URL(fullURL);
+
+  const searchParams = createSearchParams(allParams);
+  url.search = searchParams.toString();
+
+  const defaultHeaders = {
     "Content-Type": CONTENT_TYPE_APPLICATION_JSON,
-  },
-});
+  };
 
-guardianApiClient.interceptors.request.use(
-  (config) => {
-    config.params = config.params || {};
-    config.params["api-key"] = GUARDIAN_API_KEY;
+  const mergedOptions: RequestInit = {
+    ...fetchOptions,
+    headers: {
+      ...defaultHeaders,
+      ...fetchOptions.headers,
+    },
+  };
 
-    return config;
-  },
-  (error) => {
-    if (error.response) {
-      const data = error.response.data;
-      return Promise.reject(new ApiError(data.error || data.errors || data));
-    } else if (error.message) {
-      return Promise.reject(Error(error.message));
+  try {
+    const response = await fetch(url.toString(), mergedOptions);
+
+    if (!response.ok) {
+      const data = await response.json();
+      throw new ApiError(data.error || data.errors || data);
+    }
+
+    return response;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    } else if (error instanceof Error) {
+      throw new Error(error.message);
     } else {
-      return Promise.reject(Error(error));
+      throw new Error(String(error));
     }
   }
-);
+}
 
-guardianApiClient.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response) {
-      const data = error.response.data;
-      return Promise.reject(new ApiError(data.error || data.errors || data));
-    } else if (error.message) {
-      return Promise.reject(Error(error.message));
-    } else {
-      return Promise.reject(Error(error));
-    }
-  }
-);
+const guardianApiClient = {
+  async get<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
+    const response = await guardianApiFetch(endpoint, {
+      ...options,
+      method: "GET",
+    });
+    return response.json();
+  },
+};
 
 export { guardianApiClient };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import dayjs from "dayjs";
+
 export const generatePaginationArray = (current: number, total: number) => {
   if (current <= 4) {
     return Array.from({ length: Math.min(5, total) }, (_, i) => i + 1);
@@ -16,6 +18,14 @@ export const shuffleArray = <T>(array: T[]): T[] => {
     [array[i], array[j]] = [array[j], array[i]]; // Swap elements
   }
   return array;
+};
+
+export const sortArticlesByDate = (articles: Article[]): Article[] => {
+  return articles.sort((a, b) => {
+    const dateA = dayjs(a.date);
+    const dateB = dayjs(b.date);
+    return dateB.valueOf() - dateA.valueOf();
+  });
 };
 
 export const capitalize = (word: string) => {
@@ -45,4 +55,26 @@ export function isHTML(str: string): boolean {
   } catch (error) {
     return false;
   }
+}
+
+export function combineURLs(baseURL: string, relativeURL: string) {
+  return relativeURL
+    ? baseURL.replace(/\/+$/, "") + "/" + relativeURL.replace(/^\/+/, "")
+    : baseURL;
+}
+
+export function createSearchParams(
+  params: Record<string, string | string[] | undefined>
+): URLSearchParams {
+  const searchParams = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined) {
+      if (Array.isArray(value)) {
+        value.forEach((v) => searchParams.append(key, v));
+      } else {
+        searchParams.append(key, value);
+      }
+    }
+  });
+  return searchParams;
 }

--- a/src/services/articleService.ts
+++ b/src/services/articleService.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { shuffleArray } from "@/lib/utils";
+import { sortArticlesByDate } from "@/lib/utils";
 import { getGuardianApiArticles } from "@/services/guardianApiService";
 import { getNewYorkTimesApiArticles } from "@/services/newYorkTimesApiService";
 import { getNewsApiArticles } from "@/services/newsApiService";
@@ -46,7 +46,9 @@ export const getArticles = async (searchParams: {
 
     const processedResults = results.map(processApiResult);
 
-    const articles = shuffleArray(processedResults.flatMap((r) => r.articles));
+    const articles = sortArticlesByDate(
+      processedResults.flatMap((r) => r.articles)
+    );
     const totalPages = Math.max(
       ...processedResults.map((r) => r.totalPages),
       1

--- a/src/services/guardianApiService.ts
+++ b/src/services/guardianApiService.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { unstable_cacheLife as cacheLife } from "next/cache";
+
 import { randomUUID } from "crypto";
 
 import {
@@ -23,6 +25,9 @@ export const getGuardianApiArticles = async ({
   categories,
   authors,
 }: ArticleAPIParams) => {
+  "use cache";
+  cacheLife("minutes");
+
   let query = keyword;
 
   if (authors) {
@@ -63,7 +68,7 @@ export const getGuardianApiArticles = async ({
 
     return {
       data:
-        response.data?.response.results.map(
+        response?.response.results.map(
           ({ fields, webPublicationDate, sectionName }) => ({
             id: randomUUID(),
             title: fields.headline,
@@ -77,7 +82,7 @@ export const getGuardianApiArticles = async ({
             author: fields.byline,
           })
         ) || [],
-      totalPages: response.data.response.pages,
+      totalPages: response.response.pages,
     };
   } catch (error) {
     console.error(error);

--- a/src/services/newYorkTimesApiService.ts
+++ b/src/services/newYorkTimesApiService.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { unstable_cacheLife as cacheLife } from "next/cache";
+
 import {
   CATEGORY_TO_NEW_YORK_TIMES_API_CATEGORY_MAPPING,
   DEFAULT_PAGE,
@@ -20,6 +22,9 @@ export const getNewYorkTimesApiArticles = async ({
   categories,
   authors,
 }: ArticleAPIParams) => {
+  "use cache";
+  cacheLife("minutes");
+
   const fq: string[] = [];
 
   if (categories) {
@@ -71,7 +76,7 @@ export const getNewYorkTimesApiArticles = async ({
       };
     }>("/articlesearch.json", {
       params: {
-        page: Number(page) - 1 || DEFAULT_PAGE - 1,
+        page: `${Number(page) - 1 || +DEFAULT_PAGE - 1}`,
         q: keyword,
         begin_date: fromDate?.replaceAll("-", ""),
         end_date: toDate?.replaceAll("-", ""),
@@ -81,7 +86,7 @@ export const getNewYorkTimesApiArticles = async ({
 
     return {
       data:
-        response?.data?.response?.docs.map(
+        response?.response?.docs.map(
           ({
             _id,
             web_url,
@@ -109,7 +114,7 @@ export const getNewYorkTimesApiArticles = async ({
             author: byline.original,
           })
         ) || [],
-      totalPages: Math.ceil(response.data.response.meta.hits / PAGE_SIZE),
+      totalPages: Math.ceil(response.response.meta.hits / +PAGE_SIZE),
     };
   } catch (error) {
     console.error(error);

--- a/src/services/newsApiService.ts
+++ b/src/services/newsApiService.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { unstable_cacheLife as cacheLife } from "next/cache";
+
 import { randomUUID } from "crypto";
 
 import { DEFAULT_PAGE, PAGE_SIZE } from "@/config/constants";
@@ -16,6 +18,9 @@ export const getNewsApiArticles = async ({
   categories,
   authors,
 }: ArticleAPIParams) => {
+  "use cache";
+  cacheLife("minutes");
+
   let query = keyword;
 
   if (categories) {
@@ -50,7 +55,7 @@ export const getNewsApiArticles = async ({
 
     return {
       data:
-        response?.data?.articles.map(
+        response?.articles.map(
           ({
             title,
             description,
@@ -73,7 +78,7 @@ export const getNewsApiArticles = async ({
             author,
           })
         ) || [],
-      totalPages: response.data.totalResults,
+      totalPages: response.totalResults,
     };
   } catch (error) {
     console.error(error);

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -1,5 +1,9 @@
 /* eslint-disable no-unused-vars */
 declare global {
+  interface RequestOptions extends RequestInit {
+    params?: Record<string, string | string[] | undefined>;
+  }
+
   type ArticleAPIParams = {
     page?: string;
     keyword?: string;


### PR DESCRIPTION
- Migrated all API clients from Axios to native `fetch` to leverage Next.js and React's built-in caching mechanisms.
- Implemented 'useCache' and 'cacheLife('minutes')' to enable caching for all three article API services.
- Removed the Axios library dependency.
- Upgraded Next.js to the canary channel to utilize the latest caching features.