### PR TITLE
fix(api-caching): remove 'use cache' from article fetch api and 'dynamicio' from next config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,6 @@ const nextConfig: NextConfig = {
   output: "standalone",
   experimental: {
     ppr: true,
-    dynamicIO: true,
   },
   images: {
     unoptimized: true,

--- a/src/services/guardianApiService.ts
+++ b/src/services/guardianApiService.ts
@@ -1,7 +1,5 @@
 "use server";
 
-import { unstable_cacheLife as cacheLife } from "next/cache";
-
 import { randomUUID } from "crypto";
 
 import {
@@ -25,9 +23,6 @@ export const getGuardianApiArticles = async ({
   categories,
   authors,
 }: ArticleAPIParams) => {
-  "use cache";
-  cacheLife("minutes");
-
   let query = keyword;
 
   if (authors) {

--- a/src/services/newYorkTimesApiService.ts
+++ b/src/services/newYorkTimesApiService.ts
@@ -1,7 +1,5 @@
 "use server";
 
-import { unstable_cacheLife as cacheLife } from "next/cache";
-
 import {
   CATEGORY_TO_NEW_YORK_TIMES_API_CATEGORY_MAPPING,
   DEFAULT_PAGE,
@@ -22,9 +20,6 @@ export const getNewYorkTimesApiArticles = async ({
   categories,
   authors,
 }: ArticleAPIParams) => {
-  "use cache";
-  cacheLife("minutes");
-
   const fq: string[] = [];
 
   if (categories) {

--- a/src/services/newsApiService.ts
+++ b/src/services/newsApiService.ts
@@ -1,7 +1,5 @@
 "use server";
 
-import { unstable_cacheLife as cacheLife } from "next/cache";
-
 import { randomUUID } from "crypto";
 
 import { DEFAULT_PAGE, PAGE_SIZE } from "@/config/constants";
@@ -18,9 +16,6 @@ export const getNewsApiArticles = async ({
   categories,
   authors,
 }: ArticleAPIParams) => {
-  "use cache";
-  cacheLife("minutes");
-
   let query = keyword;
 
   if (categories) {


### PR DESCRIPTION
- Removed 'use cache' flag from article fetch API functions to prevent caching issues on production.
- Removed 'dynamicIO' configuration from Next.js config to avoid navigation errors.