### PR TITLE
perf(articles-api): cache articles api response

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,11 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  logging: {
+    fetches: {
+      fullUrl: true,
+    },
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "19.0.0-rc-603e6108-20241029",
         "react-dom": "19.0.0-rc-603e6108-20241029",
         "react-hook-form": "^7.53.0",
+        "server-only": "^0.0.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -6307,6 +6308,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "19.0.0-rc-603e6108-20241029",
     "react-dom": "19.0.0-rc-603e6108-20241029",
     "react-hook-form": "^7.53.0",
+    "server-only": "^0.0.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -11,6 +11,8 @@ export const DEFAULT_PAGE = "1";
 
 export const CONTENT_TYPE_APPLICATION_JSON = "application/json";
 
+export const FETCH_REVALIDATE_INTERVAL = 60;
+
 export const ROUTES = [
   {
     path: Paths.home,

--- a/src/services/articleService.ts
+++ b/src/services/articleService.ts
@@ -1,4 +1,4 @@
-"use server";
+import "server-only";
 
 import { sortArticlesByDate } from "@/lib/utils";
 import { getGuardianApiArticles } from "@/services/guardianApiService";

--- a/src/services/feedService.ts
+++ b/src/services/feedService.ts
@@ -3,6 +3,8 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import "server-only";
+
 import { shuffleArray } from "@/lib/utils";
 import { getGuardianApiArticles } from "@/services/guardianApiService";
 import { getNewYorkTimesApiArticles } from "@/services/newYorkTimesApiService";

--- a/src/services/guardianApiService.ts
+++ b/src/services/guardianApiService.ts
@@ -1,10 +1,12 @@
 "use server";
 
 import { randomUUID } from "crypto";
+import "server-only";
 
 import {
   CATEGORY_TO_GUARDIAN_API_CATEGORY_MAPPING,
   DEFAULT_PAGE,
+  FETCH_REVALIDATE_INTERVAL,
   PAGE_SIZE,
 } from "@/config/constants";
 import { guardianApiClient } from "@/lib/api-clients/guardianApiClient";
@@ -45,6 +47,7 @@ export const getGuardianApiArticles = async ({
         results: GuardianAPIArticle[];
       };
     }>("/search", {
+      next: { revalidate: FETCH_REVALIDATE_INTERVAL },
       params: {
         page: page || DEFAULT_PAGE,
         "page-size": PAGE_SIZE,

--- a/src/services/newYorkTimesApiService.ts
+++ b/src/services/newYorkTimesApiService.ts
@@ -1,8 +1,9 @@
-"use server";
+import "server-only";
 
 import {
   CATEGORY_TO_NEW_YORK_TIMES_API_CATEGORY_MAPPING,
   DEFAULT_PAGE,
+  FETCH_REVALIDATE_INTERVAL,
   PAGE_SIZE,
 } from "@/config/constants";
 import { newYorkTimesApiClient } from "@/lib/api-clients/newYorkTimesApiClient";
@@ -70,6 +71,7 @@ export const getNewYorkTimesApiArticles = async ({
         };
       };
     }>("/articlesearch.json", {
+      next: { revalidate: FETCH_REVALIDATE_INTERVAL },
       params: {
         page: `${Number(page) - 1 || +DEFAULT_PAGE - 1}`,
         q: keyword,

--- a/src/services/newsApiService.ts
+++ b/src/services/newsApiService.ts
@@ -1,8 +1,13 @@
 "use server";
 
 import { randomUUID } from "crypto";
+import "server-only";
 
-import { DEFAULT_PAGE, PAGE_SIZE } from "@/config/constants";
+import {
+  DEFAULT_PAGE,
+  FETCH_REVALIDATE_INTERVAL,
+  PAGE_SIZE,
+} from "@/config/constants";
 import { newsApiClient } from "@/lib/api-clients/newsApiClient";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -38,6 +43,7 @@ export const getNewsApiArticles = async ({
       totalResults: number;
       articles: NewsAPIArticle[];
     }>("/everything", {
+      next: { revalidate: FETCH_REVALIDATE_INTERVAL },
       params: {
         page: page || DEFAULT_PAGE,
         sources: NewsAPISources,


### PR DESCRIPTION
- Implemented caching for the articles API by setting 'revalidate' to '60' in the fetch request.
- Added and utilized 'server-only' library for server functions files to ensure efficient caching on the server-side.