### PR TITLE
fix(build-config): disable standalone output on vercel

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  output: "standalone",
+  output: process.env.DOCKERIZE ? "standalone" : undefined,
   experimental: {
     ppr: true,
   },


### PR DESCRIPTION
- Modified `next.config.ts` to conditionally set `output: 'standalone'` only when `process.env.DOCKERIZE` is true.
- This disables standalone output on Vercel deployments to improve build performance and compatibility.